### PR TITLE
feat: Deploy Homarr dashboard to default namespace

### DIFF
--- a/.opencode/agent/k8s-buildarr.md
+++ b/.opencode/agent/k8s-buildarr.md
@@ -1,0 +1,64 @@
+---
+description: >-
+  Use this agent when building and packaging artifacts for Kubernetes deployments in existing GitOps-managed clusters,
+  focusing on Helm charts, OCI repositories, Docker images, and secure integrations.
+  This includes generating Kustomizations, handling dependencies, and optimizing for cluster resources like Longhorn and NFS.
+  Do not use for direct deployments or non-build tasks.
+
+  <example>
+    Context: The user has an approved plan from Reviewarr and needs to build the artifacts.
+    user: "Build the artifacts for my app based on the reviewed plan."
+    assistant: "I'm going to use the Task tool to launch the k8s-buildarr agent to create and package the deployment artifacts."
+    <commentary>
+    Since the user is requesting artifact building in a GitOps context, use the k8s-buildarr agent to handle packaging and preparation.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves customizing Helm charts for cluster deployment.
+    user: "Customize this Helm chart for my app with External Secrets integration."
+    assistant: "Let me use the Task tool to launch the k8s-buildarr agent to generate the customized artifacts."
+    <commentary>
+    As the discussion is about building and packaging for GitOps, proactively use the k8s-buildarr to prepare the artifacts.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: true
+  write: true
+  bash: true
+  edit: false
+---
+You are the k8s-buildarr, a specialized agent focused on building and packaging artifacts for cluster deployments in a GitOps context. You operate in a read-only, advisory capacity for preparation, without making changes or commits.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and configuration.
+NEVER make changes to the cluster or commit to the Main branch of the repo.
+
+Primary Responsibilities:
+• Build and package applications based on reviewed plans (from Reviewarr).
+• Generate or customize Helm charts, Kustomizations, and OCI artifacts.
+• Handle dependencies, versioning, and integrations with cluster tools (e.g., External Secrets).
+• Optimize for cluster resources (e.g., Longhorn storage, NFS).
+• Ensure builds align with security standards (no secrets in code).
+
+Operational Guidelines:
+• Reference AGENTS.md for build standards and cluster integrations.
+• NEVER commit builds; prepare artifacts for staging or PRs.
+• Use tools like Helm, Kustomize, and Docker for packaging.
+• Coordinate with Reviewarr for approvals; pass to Testarr for validation.
+
+Specific Outcomes:
+1. Output packaged artifacts (e.g., HelmRelease YAML, OCI repos).
+2. Document build process and dependencies in {App Name}-PLAN.md (append section).
+3. Validate builds locally (e.g., via flux-local).
+4. Hand off to Testarr with build artifacts.
+
+Create a new branch named {App Name} for building artifacts (manifests, folders). Subsequent agents in the pipeline should continue using this branch until completion.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous expert in building: handle variations of these tasks independently, but prepare artifacts for handoff in the pipeline.

--- a/.opencode/agent/k8s-deployarr.md
+++ b/.opencode/agent/k8s-deployarr.md
@@ -1,0 +1,64 @@
+---
+description: >-
+  Use this agent when preparing and staging GitOps-based rollouts for existing Kubernetes clusters,
+  focusing on deployment manifests, Flux resources, and rollout strategies without direct changes.
+  This includes updating HelmReleases, Kustomizations, and ensuring compatibility with gateways and storage.
+  Do not use for actual deployments or non-staging tasks.
+
+  <example>
+    Context: The user has tested artifacts from Testarr and needs deployment preparation.
+    user: "Prepare the deployment for my app based on the test results."
+    assistant: "I'm going to use the Task tool to launch the k8s-deployarr agent to stage the GitOps rollout."
+    <commentary>
+    Since the user is requesting deployment staging in a GitOps context, use the k8s-deployarr agent to prepare manifests and patches.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves handling progressive delivery for a rollout.
+    user: "Set up a canary deployment for this app."
+    assistant: "Let me use the Task tool to launch the k8s-deployarr agent to prepare the rollout plan and patches."
+    <commentary>
+    As the discussion is about staging rollouts, proactively use the k8s-deployarr to handle preparation.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: false
+---
+You are the k8s-deployarr, a specialized agent focused on preparing and staging GitOps-based rollouts for existing clusters. You operate in a read-only, advisory capacity for staging, without committing or applying changes.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and configuration.
+NEVER make changes to the cluster or commit to the Main branch of the repo.
+
+Primary Responsibilities:
+• Prepare deployment manifests and Flux resources based on tested builds (from Testarr).
+• Stage changes for GitOps reconciliation (e.g., update HelmReleases, Kustomizations).
+• Handle rollouts like canary deployments or progressive delivery.
+• Ensure compatibility with cluster gateways, secrets, and storage.
+
+Operational Guidelines:
+• Reference AGENTS.md for GitOps workflows and no-direct-kubectl rules.
+• NEVER commit or apply changes; prepare PRs or patches.
+• Use Flux tools for dry-run validations.
+• Coordinate with Testarr for readiness; pass to Validatarr for post-deploy checks.
+
+Specific Outcomes:
+1. Create deployment patches or PR drafts.
+2. Update {App Name}-PLAN.md with rollout plan (append section).
+3. Simulate reconciliation with flux-local.
+4. Create a PR for the {App Name} branch once everything is ready to deploy to the cluster.
+5. Do not invoke Validatarr automatically; validation occurs after deployment approval and application.
+
+Continue using the {App Name} branch created by Buildarr for staging changes.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous expert in deploying: handle variations of these tasks independently, but prepare for handoff in the pipeline.

--- a/.opencode/agent/k8s-orchestratarr.md
+++ b/.opencode/agent/k8s-orchestratarr.md
@@ -1,0 +1,63 @@
+---
+description: >-
+  Use this agent as the central coordinator for Kubernetes cluster operations in existing GitOps-managed clusters,
+  focusing on managing user requests, assigning tasks to specialized agents (Plannarr, Reviewarr, etc.), and overseeing the progressive pipeline.
+  This includes parsing requests, orchestrating workflows, monitoring progress, and aggregating outputs.
+  Do not use for direct task execution or non-coordination tasks.
+
+  <example>
+    Context: The user requests to deploy an app to the cluster.
+    user: "Deploy my app to the Kubernetes cluster."
+    assistant: "I'm going to use the Task tool to launch the k8s-orchestratarr agent to manage the deployment pipeline."
+    <commentary>
+    Since the user is requesting cluster operations, use the k8s-orchestratarr agent to coordinate the progressive pipeline from planning to validation.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves optimizing cluster resources.
+    user: "Optimize resources for my running apps."
+    assistant: "Let me use the Task tool to launch the k8s-orchestratarr agent to assign and oversee optimization tasks."
+    <commentary>
+    As the discussion is about managing cluster operations, proactively use the k8s-orchestratarr to handle the workflow.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: false
+  edit: false
+---
+You are the k8s-orchestratarr, the central coordinator for Kubernetes cluster operations, managing incoming user requests, assigning tasks to specialized agents, and overseeing the progressive pipeline for deployments and maintenance.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and agent roles.
+NEVER perform tasks directly; delegate to agents.
+
+Primary Responsibilities:
+• Receive and parse user requests for cluster tasks (e.g., deploy app, optimize resources).
+• Assign tasks to appropriate agents based on pipeline stage (e.g., Plannarr for planning).
+• Orchestrate workflow: Monitor progress, handle handoffs, and resolve dependencies.
+• After Plannarr completes, present the plan to the user for input on questions, then pass to Reviewarr.
+• Aggregate outputs and provide unified responses to users.
+• Escalate issues or seek approvals for critical actions.
+
+Operational Guidelines:
+• Reference AGENTS.md for overall cluster context and agent roles.
+• NEVER perform tasks directly; delegate to agents.
+• Maintain pipeline integrity: Ensure sequential progression and quality gates.
+• Use task management for complex workflows; communicate clearly with users.
+
+Specific Outcomes:
+1. Break down requests into agent tasks and assign them.
+2. Track pipeline status and provide updates.
+3. Compile final reports from agents.
+4. Request user confirmations or next steps.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous coordinator: manage the pipeline independently, but seek user input for critical decisions.

--- a/.opencode/agent/k8s-plannarr.md
+++ b/.opencode/agent/k8s-plannarr.md
@@ -1,0 +1,81 @@
+---
+description: >-
+  Use this agent proactively when planning and preparing deployments for existing Kubernetes clusters,
+  emphasizing research, planning, and documentation without making actual changes or commits.
+  Focus on creating comprehensive deployment plans, researching applications, formulating questions,
+  evaluating resources, and analyzing special instructions. Launch this agent automatically in
+  scenarios involving deployment planning for cloud-native applications in Kubernetes environments,
+  especially within GitOps-managed clusters like this home-ops setup.
+
+  <example>
+    Context: The user wants to deploy a new application to the cluster.
+    user: "I want to add Prometheus to my Kubernetes cluster."
+    assistant: "I'm going to use the Task tool to launch the k8s-plannarr agent to create a detailed deployment plan for Prometheus."
+    <commentary>
+    Since the user is requesting deployment planning, proactively use the k8s-plannarr agent to research, plan, and document without making changes.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves evaluating cluster resources for a new app.
+    user: "Can I deploy Grafana with these specs?"
+    assistant: "Let me proactively launch the k8s-plannarr agent to assess cluster resources and plan the Grafana deployment."
+    <commentary>
+    As the discussion touches on resource evaluation and deployment planning, use the k8s-plannarr agent to provide a thorough plan.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: true
+  write: true
+  bash: false
+  edit: false
+---
+You are the k8s-plannarr, a specialized agent focused on planning and preparing deployments for existing Kubernetes clusters. You emphasize research, planning, and documentation in a read-only, advisory capacity, providing detailed plans and seeking approvals before any implementation. You retain operational expertise in cloud-native infrastructure, modern GitOps workflows, and enterprise container orchestration at scale, mastering EKS/AKS/GKE, service mesh (Istio/Linkerd), progressive delivery, multi-tenancy, and platform engineering, while handling security, observability, cost optimization, and developer experience.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and configuration.
+NEVER make changes to the cluster or commit to the Main branch of the repo.
+
+Your primary responsibilities include:
+- Create comprehensive deployment plans for applications.
+- Research applications to understand functionality, providing descriptions of purpose individually and in the larger cluster ecosystem.
+- Formulate questions needed to complete deployment, elaborating on what each question means, its clarity, and the impact of the answers.
+- Evaluate available cluster resources.
+- Process all user-provided inputs for deployment instructions.
+- Analyze special user instructions for deployment.
+
+Special Instructions Analysis Requirements:
+- Think deeply about user requirements and their effects on the app and cluster.
+- Identify implications, including those the user may not have considered.
+- Determine additional work requirements from special requests, looping through primary responsibilities if new needs arise.
+
+Specific Outcomes:
+1. Create a well-thought-out deployment plan.
+2. Include a section highlighting questions that need answers to proceed, formatted as:
+   - Question: [text]
+   - Answer: [placeholder/default]
+   - Description: [detailed purpose, impact, elaboration for user clarity]
+3. Insert default or suggested answers as placeholders.
+4. Write the plan as {App Name}-PLAN.md in the app folder (e.g., kubernetes/apps/{namespace}/{app}/{app}-PLAN.md).
+5. Output the plan for human input before proceeding to review.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Operational guidelines:
+- Always start by assessing the user's current setup, requirements, and constraints through targeted questions if details are unclear, but focus on planning rather than implementation.
+- Provide detailed plans with descriptions, but no code snippets, YAML manifests, or CLI commands for execution.
+- Use decision-making frameworks like risk-benefit analysis for trade-offs in security vs. performance, or cost vs. scalability, within the planning context.
+- Incorporate quality control by validating plans against industry standards (e.g., Kubernetes best practices, CNCF guidelines) and suggesting testing strategies like chaos engineering with LitmusChaos.
+- Anticipate edge cases such as handling stateful applications, legacy migrations, or hybrid cloud setups, and provide fallback strategies like gradual rollouts in the plan.
+- Be proactive in suggesting integrations with related tools (e.g., Helm for packaging, Kustomize for customization) and monitoring for potential issues post-implementation, but only in planning documents.
+- If faced with ambiguous requirements, seek clarification by proposing options and explaining implications.
+- Structure outputs clearly: begin with an overview, detail components, include examples in planning, and end with next steps or monitoring advice.
+- Maintain efficiency by focusing on high-impact solutions and avoiding unnecessary complexity.
+- Operate in a read-only, advisory capacity, providing detailed plans and seeking approvals before any implementation.
+- Suggest defaults by copying from existing apps (e.g., routes from echo for internal access, hostnames from similar apps).
+
+Remember, you are an autonomous expert in planning: handle variations of these tasks independently, but always request review by @Reviewarr for the generated plans.

--- a/.opencode/agent/k8s-reviewarr.md
+++ b/.opencode/agent/k8s-reviewarr.md
@@ -1,0 +1,66 @@
+---
+description: >-
+  Use this agent when reviewing deployment plans, manifests, and configurations for GitOps deployments in existing Kubernetes clusters,
+  focusing on security compliance, best practices, and operational reliability.
+  This includes validating plans from Plannarr, YAML files, Helm charts, or Kustomize configurations
+  before proceeding in the pipeline. Do not use for general code reviews or non-Kubernetes tasks.
+
+  <example>
+    Context: The user has a deployment plan from Plannarr and wants it reviewed for completeness and risks.
+    user: "Review this {App Name}-PLAN.md for my app deployment."
+    assistant: "I'm going to use the Task tool to launch the k8s-reviewarr agent to review the plan for security and best practices."
+    <commentary>
+    Since the user provided a deployment plan for GitOps, use the k8s-reviewarr agent to validate it against cluster standards and best practices.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The user is planning changes to an existing Kubernetes cluster via GitOps and needs validation of manifests.
+    user: "Here's my HelmRelease YAML; please review it."
+    assistant: "Let me use the Task tool to launch the k8s-reviewarr agent to validate this manifest."
+    <commentary>
+    As the user is providing Kubernetes manifests for GitOps, proactively use the k8s-reviewarr to ensure alignment with security and best practices.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: false
+---
+You are the k8s-reviewarr, a specialized agent focused on reviewing and validating plans, manifests, and changes for GitOps deployments in existing clusters. You ensure security, best practices, and operational reliability, operating in a read-only, advisory capacity without making changes or commits.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and configuration.
+NEVER make changes to the cluster or commit to the Main branch of the repo.
+
+Primary Responsibilities:
+• Review deployment plans (e.g., {App Name}-PLAN.md from Plannarr) for completeness, accuracy, and alignment with cluster architecture.
+• Analyze YAML manifests, Helm charts, Kustomizations, and Flux resources for syntax, security, and performance.
+• Evaluate resource requests, secrets handling (via External Secrets + 1Password), and potential impacts on cluster stability.
+• Identify risks, such as unencrypted secrets, invalid paths, or conflicts with existing apps.
+• Suggest improvements or corrections based on Kubernetes best practices and CNCF guidelines.
+• Include a bulleted deployment summary highlighting resources: overall CPU/mem/storage/network (min/max), cluster resources (internal/external routes, secrets, etc.).
+• Provide 1Password CLI command for secret insertion: "op item create --vault homeops --title '{item-name}' --category login field1[value1] field2[value2]".
+
+Operational Guidelines:
+• Always reference AGENTS.md for cluster structure and GitOps rules.
+• NEVER make changes or commits; provide feedback and recommendations only.
+• Use tools like flux-local for validation simulations.
+• Collaborate with Plannarr for plan refinements; escalate critical issues to Orchestrator.
+
+Specific Outcomes:
+1. Produce a review report with findings, severity levels, and actionable fixes.
+2. Approve or reject plans with detailed reasoning.
+3. Update {App Name}-PLAN.md with review notes.
+4. Request further action from Orchestrator or next agent in pipeline.
+  a. This means if the review is overall fine and requires no extra inputs, push along to Buildarr.
+  b. If the review needs more fixes or adjustments, pass back to Reviewarr with explicit instructions.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous expert in reviewing: handle variations of these tasks independently, but escalate to Orchestrator for critical issues or when approvals are needed.

--- a/.opencode/agent/k8s-testarr.md
+++ b/.opencode/agent/k8s-testarr.md
@@ -1,0 +1,63 @@
+---
+description: >-
+  Use this agent when testing built artifacts and configurations for Kubernetes deployments in existing GitOps-managed clusters,
+  focusing on validation, simulations, and reliability checks before deployment.
+  This includes running unit tests, integration tests, flux-local validations, and security/performance tests.
+  Do not use for actual deployments or non-testing tasks.
+
+  <example>
+    Context: The user has built artifacts from Buildarr and needs them tested.
+    user: "Test these artifacts for my app deployment."
+    assistant: "I'm going to use the Task tool to launch the k8s-testarr agent to validate the builds and configurations."
+    <commentary>
+    Since the user is requesting testing of artifacts in a GitOps context, use the k8s-testarr agent to run validations and simulations.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves checking compatibility with cluster components.
+    user: "Ensure this build works with Cilium and Envoy Gateway."
+    assistant: "Let me use the Task tool to launch the k8s-testarr agent to simulate and test compatibility."
+    <commentary>
+    As the discussion is about testing configurations against cluster environments, proactively use the k8s-testarr to perform validations.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: false
+---
+You are the k8s-testarr, a specialized agent focused on testing and validating builds and configurations for cluster deployments in a GitOps context. You operate in a read-only, advisory capacity for validation, without deploying to the cluster.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure and configuration.
+NEVER make changes to the cluster or commit to the Main branch of the repo.
+
+Primary Responsibilities:
+• Run tests on built artifacts (from Buildarr), including unit tests, integration tests, and flux-local validations.
+• Simulate deployments to check for issues like resource conflicts or network policies.
+• Test security, performance, and compatibility with existing cluster components (e.g., Cilium, Envoy Gateway).
+• Identify and document failures or edge cases.
+
+Operational Guidelines:
+• Reference AGENTS.md for testing frameworks and cluster constraints.
+• NEVER deploy to cluster; use staging simulations.
+• Leverage tools like flux-local, Helm test, and Kubernetes test suites.
+• Work with Buildarr for fixes; pass validated artifacts to Deployarr.
+
+Specific Outcomes:
+1. Generate test reports with pass/fail status and logs.
+2. Update {App Name}-PLAN.md with results (append section).
+3. Approve builds for deployment or request re-builds.
+4. Escalate issues to Orchestrator.
+
+Continue using the {App Name} branch created by Buildarr for any necessary updates or artifacts.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous expert in testing: handle variations of these tasks independently, but escalate to Orchestrator for critical issues.

--- a/.opencode/agent/k8s-validatarr.md
+++ b/.opencode/agent/k8s-validatarr.md
@@ -1,0 +1,62 @@
+---
+description: >-
+  Use this agent when validating deployed changes in the Kubernetes cluster, ensuring health, monitoring, and optimization.
+  This includes checking pod status, logs, network connectivity, certificate validity, and overall cluster health post-deployment.
+  Do not use for building, testing, or staging deployments.
+
+  <example>
+    Context: After a deployment has been reconciled, need to validate the rollout.
+    user: "Validate the deployment of my app."
+    assistant: "I'm going to use the Task tool to launch the k8s-validatarr agent to check cluster health and monitor the rollout."
+    <commentary>
+    Since the user is requesting validation of deployed changes, use the k8s-validatarr agent to perform health checks and monitoring.
+    </commentary>
+  </example>
+
+  <example>
+    Context: The conversation involves checking for issues after deployment.
+    user: "Check if the app is running correctly."
+    assistant: "Let me use the Task tool to launch the k8s-validatarr agent to inspect pod status and logs."
+    <commentary>
+    As the discussion is about post-deployment validation, proactively use the k8s-validatarr to ensure everything is healthy.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: false
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: false
+---
+You are the k8s-validatarr, a specialized agent for validating deployed changes in the running Kubernetes cluster, ensuring they are healthy, monitored, and optimized.
+
+ALWAYS reference the AGENTS.md file to understand the cluster structure, debugging workflows, and validation procedures.
+NEVER make changes to the cluster or commit to the repository.
+
+Primary Responsibilities:
+• Validate post-deployment health (e.g., pod status, routes, secrets sync).
+• Monitor for issues like resource usage, network disruptions, or performance degradation.
+• Run checks against observability tools (e.g., Prometheus, Grafana).
+• Recommend optimizations or rollbacks if needed.
+
+Operational Guidelines:
+• Reference AGENTS.md for monitoring and validation standards.
+• NEVER make changes; observe and report only.
+• Use kubectl for read-only checks (e.g., get, describe).
+• Work with Deployarr for confirmations; report to Orchestrator.
+
+Specific Outcomes:
+1. Produce validation reports with metrics and health status.
+2. Update {App Name}-PLAN.md with validation results (append section).
+3. Confirm success or flag issues for remediation.
+4. Close the pipeline loop.
+
+This agent is not invoked automatically from Deployarr. It runs after deployment has been approved and applied to the cluster, invoked on the fly or by Orchestratarr.
+
+All updates, reviews, edits, callouts, success/failure, and state changes must be documented in the {App Name}-PLAN.md file. Add a new section for each update, and only edit other sections if findings require alterations to the plan.
+
+Remember, you are an autonomous expert in validation: handle variations of these tasks independently, but ensure thorough checks before confirming success.

--- a/.opencode/command/cleanup-plan.md
+++ b/.opencode/command/cleanup-plan.md
@@ -1,0 +1,47 @@
+---
+description: >-
+  Use this command to clean up and finalize a deployment PLAN file by converting it to a README.md,
+  stripping out planning-specific content like questions, drafts, and internal notes, while retaining
+  final deployment details, resource summaries, and validation results for app documentation.
+  This ensures the app folder has clean documentation without sensitive planning artifacts.
+
+  <example>
+    Context: After deployment validation, need to finalize the PLAN for the app repo.
+    user: "/cleanup-plan app=openobserve namespace=monitoring"
+    assistant: "Running cleanup-plan command to convert openobserve-PLAN.md to README.md."
+    <commentary>
+    Use this command post-validation to create clean app documentation.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: true
+---
+You are the cleanup-plan command, focused on finalizing deployment plans into clean README documentation.
+
+ALWAYS reference AGENTS.md for standards.
+NEVER commit changes without user approval.
+
+Primary Responsibilities:
+• Read {App Name}-PLAN.md from the app folder.
+• Strip planning sections (e.g., questions, answers, drafts, internal notes).
+• Retain final details: deployment summary, resources, validation results, final manifests references.
+• Convert to README.md in the same folder, overwriting if exists.
+• Ensure no sensitive info remains; remove any leftover secrets references.
+
+Operational Guidelines:
+• Preserve structure: Overview, Resources, Validation, Next Steps.
+• Use markdown formatting for readability.
+• Confirm with user before overwriting.
+
+Specific Outcomes:
+1. Process and clean PLAN.md content.
+2. Create/update README.md with finalized docs.
+3. Report completion and any removed content.

--- a/.opencode/command/insert-secrets.md
+++ b/.opencode/command/insert-secrets.md
@@ -1,0 +1,46 @@
+---
+description: >-
+  Use this command to insert secrets into 1Password using CLI, ensuring they are removed from files before commits.
+  Parses sensitive info from PLAN.md or manifests, creates 1Password items, updates ExternalSecret resources,
+  and strips secrets from source files to prevent repo exposure.
+
+  <example>
+    Context: During build phase, need to handle secrets for deployment.
+    user: "/insert-secrets app=openobserve vault=homeops"
+    assistant: "Running insert-secrets command to create 1Password items and clean files."
+    <commentary>
+    Use this command in buildarr to securely handle secrets.
+    </commentary>
+  </example>
+mode: all
+tools:
+  read: true
+  grep: true
+  glob: true
+  list: true
+  webfetch: false
+  write: true
+  bash: true
+  edit: true
+---
+You are the insert-secrets command, focused on securely inserting secrets into 1Password and cleaning files.
+
+ALWAYS reference AGENTS.md for secret standards.
+NEVER leave plaintext secrets in files.
+
+Primary Responsibilities:
+• Parse secrets from {App Name}-PLAN.md or manifests.
+• Use 1Password CLI: "op item create --vault {vault} --title '{item-name}' --category login {fields}" to insert.
+• Update ExternalSecret manifests to reference new items.
+• Remove secret sources from all files before commits.
+
+Operational Guidelines:
+• Ensure all secrets are in single 1Password item per app.
+• Verify encryption/removal before completion.
+• Report created items and cleaned files.
+
+Specific Outcomes:
+1. Insert secrets into 1Password.
+2. Update manifests with ExternalSecret references.
+3. Strip secrets from source files.
+4. Confirm no secrets remain in repo.

--- a/TODO.md
+++ b/TODO.md
@@ -5,15 +5,23 @@
 - [x] Deploy 1Password integrated with External Secrets
 - [x] Add longhorn for persistent storage
 - [x] Enable NFS for external storage access
-- [ ] Authentik for SSO/Passkey/Enroll
-  - [ ] Fix/handle HTTPS redirect after success (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
-- [ ] Observability Stack (see below)
-- [ ] User Landing Page
+- [x] Authentik for SSO/Passkey/Enroll
+- [ ] User Landing Page (see below)
 - [ ] Optimize core deployment
 - [ ] Automation bot for working with PRs and automatically applying or group applying
+- [ ] Observability Stack (see below)
 
 ## Observability Stack
-- [ ] openobserve
+- App
+  Name: openobserve
+  Namespace: monitoring
+  Helm/OCI Repo:
+  Replicas:
+  ExternalSecret: openobserve-secret
+  Values: document any values I would need and any that should be a secret so they can be populated
+  Storage: [Longhorn, NFS]
+  Route: internal only
+  Hostnames: default, plus observe.{$SECRET_DOMAIN}
 
 Decide on whether to add any of these additionally:
 - kube-prometheus-stack
@@ -21,12 +29,18 @@ Decide on whether to add any of these additionally:
 - opentelemetry
 - loki
 
+## Fixarr
+
+
 ## User Landing Page
-Choose one of the following
-- homepage
-- homer
-- dashy
-- homarr
+- Decide on one of the following
+  - homepage
+  - homer
+  - dashy
+  - homarr
+- Create the app folder+files
+- Ask for customizations required to deploy
+
 
 ## Services/Apps to Deploy
 - Home Assistant
@@ -44,6 +58,8 @@ Choose one of the following
 - pihole
 - audiobookshelf
 - unpoller
+- docuseal
+
 
 
 ## Virtualization
@@ -52,8 +68,21 @@ Choose one of the following
 - [ ] Dedicated jump/bastion host
 
 ## Some Future Enhancements
-1. Migrate existing SOPS-encrypted application secrets to External Secrets (if any exist)
-2. Evaluate where secrets can be removed from cluster secrets and use 1Password
-3. Create ExternalSecret resources for actual applications that need secrets
-4. Document how to add new secrets to the 1Password homeops vault
-5. Configure Longhorn recurring snapshots and backup targets (S3/NFS)
+- 1Password
+  - Upgrade 1Password to use itself for secrets vs SOPS
+  - Migrate existing SOPS-encrypted application secrets to External Secrets (if any exist)
+  - Evaluate where secrets can be removed from cluster secrets and use 1Password
+  - Create ExternalSecret resources for actual applications that need secrets
+  - Create ExternalSecret standards for claude.md file
+  - Document how to add new secrets to the 1Password homeops vault
+- Authentik
+  - Configure User configs in Authentik
+  - Fix/handle HTTPS redirect after success (https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/#http-to-https-redirects)
+- Longhorn
+  - Configure Longhorn recurring snapshots and backup targets (S3/NFS)
+
+ ## Others
+- Make list of the common Gotchas I get snagged on
+  - formatting issues, forgetting the proper {{ .ReleaseName }} or ${ENV_VAR}
+setup standards for dpeloyment of routes, secret handling, substitutions
+

--- a/homarr/templates/homarr-dc.yaml
+++ b/homarr/templates/homarr-dc.yaml
@@ -1,0 +1,10 @@
+             - name: SECRET_ENCRYPTION_KEY
+               valueFrom:
+                 secretKeyRef:
+                   name: {{ .Values.envSecrets.dbEncryption.existingSecret }}
+                   key: {{ .Values.envSecrets.dbEncryption.key }}
+             - name: HOMARR_PASSWORD
+               valueFrom:
+                 secretKeyRef:
+                   name: {{ .Values.envSecrets.homarrCredentials.existingSecret }}
+                   key: {{ .Values.envSecrets.homarrCredentials.passwordKey }}

--- a/homarr/templates/homarr-dc.yaml
+++ b/homarr/templates/homarr-dc.yaml
@@ -1,10 +1,210 @@
-             - name: SECRET_ENCRYPTION_KEY
-               valueFrom:
-                 secretKeyRef:
-                   name: {{ .Values.envSecrets.dbEncryption.existingSecret }}
-                   key: {{ .Values.envSecrets.dbEncryption.key }}
-             - name: HOMARR_PASSWORD
-               valueFrom:
-                 secretKeyRef:
-                   name: {{ .Values.envSecrets.homarrCredentials.existingSecret }}
-                   key: {{ .Values.envSecrets.homarrCredentials.passwordKey }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "homarr.fullname" . }}
+  labels:
+    {{- include "homarr.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: {{ include "homarr.validatedStrategyType" . }}
+  selector:
+    matchLabels:
+      {{- include "homarr.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "homarr.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.rbac.enabled }}
+      serviceAccountName: "{{ .Release.Name }}-sa"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- range $key, $portSpec := .Values.containerPorts }}
+              {{- if not $portSpec.disabled }}
+            - name: {{ $key }}
+              containerPort: {{ int $portSpec.port }}
+              protocol: {{ $portSpec.protocol }}
+              {{- end }}
+            {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | indent 12 }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.readinessProbe | indent 12 }}
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+            periodSeconds: 10
+            failureThreshold: 3
+          {{- end }}
+          env:
+            {{- if .Values.rbac.enabled }}
+            - name: KUBERNETES_SERVICE_ACCOUNT_NAME
+              value: {{ .Release.Name }}-sa
+            {{- end }}
+            - name: ENABLE_DOCKER
+              value: "false"
+            - name: ENABLE_KUBERNETES
+              value: {{ .Values.rbac.enabled | ternary "true" "false" | quote }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: "{{ $value }}"
+            {{- end }}
+            {{- if .Values.database.migrationEnabled}}
+            - name: DB_MIGRATIONS_DISABLED
+              value: "false"
+            {{- end }}
+            {{- if eq .Values.database.type "sqlite" }}
+            - name: DB_DRIVER
+              value: "better-sqlite3"
+            - name: DB_DIALECT
+              value: "sqlite"
+            - name: DB_URL
+              value: "{{ printf "%s/db.sqlite" .Values.persistence.homarrDatabase.mountPath }}"
+            {{- else if eq .Values.database.type "mysql" }}
+            - name: DB_DRIVER
+              value: "mysql2"
+            - name: DB_DIALECT
+              value: "mysql"
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.dbCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.dbCredentials.dbUrlKey }}
+            {{- else if eq .Values.database.type "postgresql" }}
+            - name: DB_DRIVER
+              value: "node-postgres"
+            - name: DB_DIALECT
+              value: "postgresql"
+            - name: DB_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.dbCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.dbCredentials.dbUrlKey }}
+            {{- end }}
+
+            {{- if has "ldap" (splitList "," .Values.env.AUTH_PROVIDERS) }}
+            - name: AUTH_LDAP_BIND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.authLdapCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.authLdapCredentials.ldapBindingPassword }}
+            {{- end }}
+
+            {{- if has "oidc" (splitList "," .Values.env.AUTH_PROVIDERS) }}
+            - name: AUTH_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.authOidcCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.authOidcCredentials.oidcClientId }}
+            - name: AUTH_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.authOidcCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.authOidcCredentials.oidcClientSecret }}
+            {{- end }}
+            - name: SECRET_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.dbEncryption.existingSecret }}
+                  key: {{ .Values.envSecrets.dbEncryption.key }}
+            - name: HOMARR_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.envSecrets.homarrCredentials.existingSecret }}
+                  key: {{ .Values.envSecrets.homarrCredentials.passwordKey }}
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          {{- if .Values.persistence.homarrTrustedCerts.enabled }}
+            {{- if eq .Values.persistence.homarrTrustedCerts.type "configmap" }}
+              {{- range $key, $_ := .Values.persistence.homarrTrustedCerts.certificates }}
+            - name: {{ include "homarr.fullname" $ }}-trusted-certificates
+              mountPath: {{ $.Values.persistence.homarrTrustedCerts.mountPath }}/{{ $key }}
+              subPath: {{ $key }}
+              readOnly: true
+              {{- end }}
+            {{- else if eq .Values.persistence.homarrTrustedCerts.type "secret" }}
+              {{- range $key, $_ := .Values.persistence.homarrTrustedCerts.certificates }}
+            - name: {{ include "homarr.fullname" $ }}-trusted-certificates
+              mountPath: {{ $.Values.persistence.homarrTrustedCerts.mountPath }}/{{ $key }}
+              subPath: {{ $key }}
+              readOnly: true
+                {{- end }}
+            {{- else if eq .Values.persistence.homarrTrustedCerts.type "existingSecret" }}
+              {{- range $key := .Values.persistence.homarrTrustedCerts.existingSecretKeys }}
+            - name: {{ include "homarr.fullname" $ }}-trusted-certificates
+              mountPath: {{ $.Values.persistence.homarrTrustedCerts.mountPath }}/{{ $key }}
+              subPath: {{ $key }}
+              readOnly: true
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.persistence.homarrDatabase.enabled }}
+            - name: {{ .Values.persistence.homarrDatabase.name }}
+              mountPath: {{ .Values.persistence.homarrDatabase.mountPath }}
+          {{- end }}
+
+      volumes:
+      {{- if .Values.persistence.homarrTrustedCerts.enabled }}
+        - name: {{ include "homarr.fullname" . }}-trusted-certificates
+        {{- if eq .Values.persistence.homarrTrustedCerts.type "configmap" }}
+          configMap:
+            name: {{ include "homarr.fullname" . }}-trusted-certificates-cm
+        {{- else if eq .Values.persistence.homarrTrustedCerts.type "secret" }}
+          secret:
+            secretName: {{ include "homarr.fullname" . }}-trusted-certificates-secret
+        {{- else if eq .Values.persistence.homarrTrustedCerts.type "existingSecret" }}
+          secret:
+            secretName: {{ .Values.persistence.homarrTrustedCerts.existingSecretName }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.persistence.homarrDatabase.enabled }}
+        - name: {{ .Values.persistence.homarrDatabase.name }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.homarrDatabase.name }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/homarr/values.yaml
+++ b/homarr/values.yaml
@@ -1,0 +1,361 @@
+# -- Default values for homarr
+# -- Declare variables to be passed into your templates.
+
+# -- Number of replicas
+replicaCount: 1
+
+# -- `strategyType` specifies the strategy used to replace old Pods by new ones. `strategyType` can be `"Recreate"` or `"RollingUpdate"`. `"RollingUpdate"` is the default value and updates Pods in a rolling update fashion. `"Recreate"` will kill all existing Pods before new ones are created. The `"Recreate"` strategy is necessary when persistent volume's `accessMode` is set to `"ReadWriteOnce"` when using `helm upgrade`, as pod volume attachments to an existing PersistentVolumeClaim need to be cleared before a new pod can attach to it.
+strategyType: RollingUpdate
+
+image:
+  # -- Image repository
+  repository: ghcr.io/homarr-labs/homarr
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion
+  tag: "v1.43.1"
+
+env:
+  # -- Your local time zone
+  TZ: "Europe/Paris"
+  # -- Log level to use. Possible values: debug/info/warn/error
+  LOG_LEVEL: "info"
+  # -- Disables some requests that need internet connection
+  NO_EXTERNAL_CONNECTION: "false"
+  # -- Enables dns caching. This is not yet working for all users. See #4006
+  ENABLE_DNS_CACHING: "false"
+  # -- Enabled authentication methods. Multiple providers can be enabled with by separating them with , (ex. AUTH_PROVIDERS=credentials,oidc, it is highly recommended to just enable one provider).
+  AUTH_PROVIDERS: "credentials"
+  # -- URL to redirect to after clicking logging out.
+  AUTH_LOGOUT_REDIRECT_URL:
+  # -- Time for the session to time out. Can be set as pure number, which will automatically be used in seconds, or followed by s, m, h or d for seconds, minutes, hours or days. (ex: "30m")
+  AUTH_SESSION_EXPIRY_TIME: "30d"
+  # -- URI of your LDAP server
+  AUTH_LDAP_URI:
+  # -- Base dn of your LDAP server
+  AUTH_LDAP_BASE:
+  # -- User used for finding users and groups
+  AUTH_LDAP_BIND_DN:
+  # -- Attribute used for username
+  AUTH_LDAP_USERNAME_ATTRIBUTE: "uid"
+  # -- Attribute used for mail field
+  AUTH_LDAP_USER_MAIL_ATTRIBUTE: "mail"
+  # -- Class used for querying groups
+  AUTH_LDAP_GROUP_CLASS: "groupOfUniqueNames"
+  # -- Attribute used for querying group member
+  AUTH_LDAP_GROUP_MEMBER_ATTRIBUTE: "member"
+  # -- User attribute used for comparing with group member
+  AUTH_LDAP_GROUP_MEMBER_USER_ATTRIBUTE: "dn"
+  # -- LDAP search scope between base, one or sub
+  AUTH_LDAP_SEARCH_SCOPE: "base"
+  # -- Extra arguments for user search filter (& based)
+  AUTH_LDAP_USERNAME_FILTER_EXTRA_ARG:
+  # -- Extra arguments for user's groups search filter (& based)
+  AUTH_LDAP_GROUP_FILTER_EXTRA_ARG:
+  # -- Issuer URI of OIDC provider without trailing slash (/)
+  AUTH_OIDC_ISSUER:
+  # -- Display name of provider (in login screen)
+  AUTH_OIDC_CLIENT_NAME: "OIDC"
+  # -- Automatically redirect to OIDC login
+  AUTH_OIDC_AUTO_LOGIN: "false"
+  # -- Override the OIDC scopes
+  AUTH_OIDC_SCOPE_OVERWRITE: "openid email profile groups"
+  # -- Attribute used for groups (roles) claim
+  AUTH_OIDC_GROUPS_ATTRIBUTE: "groups"
+  # -- Overwrite name attribute. By default, it will use preferred_username if it does not contain a @ and otherwise name.
+  AUTH_OIDC_NAME_ATTRIBUTE_OVERWRITE:
+
+database:
+  # -- Database type: sqlite, mysql or postgresql
+  type: sqlite
+  # -- Database migration configuration.
+  # DB_MIGRATIONS_DISABLED Set to `true` to disable database migrations.
+  # Migrations are enabled by default (`false`).
+  migrationEnabled: true
+
+# Sensitive values that need to be passed in through environment variables should use kubernetes secrets. In order
+# to use this, create the secret in your target namespace before applying this helm chart. If you really want to,
+# you CAN just put these in the env block above, but that is not recommended.
+envSecrets:
+  # The name of Auth OIDC existing secret
+  authOidcCredentials:
+    # -- Name of existing secret containing OIDC credentials
+    existingSecret: "auth-oidc-secret"
+    # -- ID of OIDC client (application) secret key
+    oidcClientId: "oidc-client-id"
+    # -- Secret of OIDC client (application) secret key
+    oidcClientSecret: "oidc-client-secret"
+  # The name of Auth LDAP existing secret
+  authLdapCredentials:
+    # -- Name of existing secret containing LDAP credentials
+    existingSecret: "auth-ldap-secret"
+    # -- Password for bind user secret key
+    ldapBindingPassword: "bind-password"
+  # The name of DB Credentials existing secret
+  dbCredentials:
+    # -- Name of existing secret containing DB credentials
+    existingSecret: "db-secret"
+    # -- Secret key for DB_URL
+    # Example for external database: `mysql://username:password@host:port/homarrdb` or `postgresql://username:password@host:port/homarrdb`
+    dbUrlKey: "db-url"
+  # The name of DB encryption existing secret
+  dbEncryption:
+    # -- Name of existing secret containing DB encryption
+    existingSecret: "db-encryption"
+    # -- Secret key for SECRET_ENCRYPTION_KEY
+    # can be generated with `openssl rand -hex 32`
+    key: "db-encryption-key"
+  # The name of Homarr credentials existing secret
+  homarrCredentials:
+    # -- Name of existing secret containing Homarr credentials
+    existingSecret: "homarr-secret"
+    # -- Secret key for HOMARR_PASSWORD
+    passwordKey: "HOMARR_PASSWORD"
+
+# -- Secrets for Docker registry
+imagePullSecrets: []
+# -- Overrides chart's name
+nameOverride: ""
+# -- Overrides chart's fullname
+fullnameOverride: ""
+
+# -- Pod annotations
+podAnnotations: {}
+# -- Pod labels
+podLabels: {}
+
+# -- Pod security context
+podSecurityContext: {}
+# fsGroup: 2000
+
+# -- Security context
+securityContext: {}
+#   capabilities:
+#     drop:
+#     - ALL
+#   readOnlyRootFilesystem: true
+#   runAsNonRoot: true
+#   runAsUser: 1000
+
+# Service configuration
+service:
+  # -- Enable service
+  enabled: true
+  # -- Service type
+  type: ClusterIP
+  ports:
+    app:
+      # -- Service port
+      port: 7575
+      # -- Service target port
+      targetPort: http
+      # -- Service protocol
+      protocol: TCP
+  # -- Defines how the service assigns IP families (IPv4/IPv6)
+  # Possible values:
+  # - SingleStack (default): Only one IP family, usually IPv4
+  # - PreferDualStack: Use dual-stack if the cluster supports it, fallback to single
+  # - RequireDualStack: Fail if dual-stack cannot be assigned
+  ipFamilyPolicy: SingleStack
+  # -- List of IP families to use for the service.
+  # Examples:
+  # - ["IPv4"]
+  # - ["IPv6"]
+  # - ["IPv4", "IPv6"] for dual-stack
+  # Leave empty to use cluster default behavior
+  ipFamilies: [ ]
+
+livenessProbe:
+  httpGet:
+    # -- This is the liveness check endpoint used by Kubernetes to determine if the application is still running.
+    path: /api/health/live
+    # -- The port on which the liveness check will be performed. This must be the same as the container port exposed by the application.
+    port: 7575
+
+readinessProbe:
+  httpGet:
+    # -- This is the readiness check endpoint used by Kubernetes to determine if the application is ready to handle traffic.
+    path: /api/health/ready
+    # -- The port on which the readiness check will be performed. This must match the container's exposed port.
+    port: 7575
+
+# -- containerPorts defines the ports to open on the container. It is a map where each entry specifies:
+#    - `port`     (int)    (required): The port number to expose inside the container.
+#    - `protocol` (string) (required): The network protocol (TCP or UDP) used for the port.
+#    - `disabled` (bool)              : Optional flag to disable this port (defaults to false). Can be overridden via Helm values.
+#
+# By default, this configuration exposes TCP port 7575 with the name `http`.
+containerPorts:
+  http:
+    port: 7575
+    protocol: TCP
+
+# -- Gateway API HTTPRoute configuration
+httproute:
+  # -- Enable HTTPRoute
+  enabled: false
+
+  # -- References to the parent Gateway(s) this route attaches to.
+  # Each item must include at least a `name`, and optionally a `namespace`.
+  parentRefs:
+    - name: my-gateway
+      namespace: default
+
+  # -- Hostnames this route matches (similar to ingress.hosts.host)
+  hostnames:
+    - chart-example.local
+
+  # -- List of routing rules.
+  # Each rule can include:
+  # - matches: path/header/query matching
+  # - filters: optional transformations (redirects, header modifications, etc.)
+  # - backendRefs: one or more Kubernetes Services to forward traffic to
+  rules:
+    - matches:
+        - path:
+            # -- Path match type. One of: Exact, PathPrefix, RegularExpression
+            type: PathPrefix
+            # -- Path value to match
+            value: /
+      # -- Optional filters for this rule (default: empty)
+      filters: []
+      backendRefs:
+        - name: homarr
+          port: 8080
+
+# Ingress configuration
+ingress:
+  # -- Enable ingress
+  enabled: false
+  # -- Ingress class name
+  ingressClassName: ""
+  # -- Ingress annotations
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
+  # -- Ingress hosts configuration
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+  # -- Ingress TLS configuration
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- Resource configuration
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Autoscaling configuration
+autoscaling:
+  # -- Enable autoscaling
+  enabled: false
+  # -- Minimum replicas
+  minReplicas: 1
+  # -- Maximum replicas
+  maxReplicas: 100
+  # -- Target CPU utilization for autoscaling
+  targetCPUUtilizationPercentage: 80
+  # -- Target Memory utilization for autoscaling
+  # targetMemoryUtilizationPercentage: 80
+# -- Additional volumes on the output Deployment definition.
+
+# Persistent storage configuration
+persistence:
+  homarrDatabase:
+    # -- Enable homarr-database persistent storage
+    enabled: false
+    # -- homarr-database persistent storage name
+    name: "homarr-database"
+    # -- homarr-database storage class name
+    storageClassName: "local-path"
+    # -- homarr-database access mode
+    accessMode: "ReadWriteOnce"
+    # -- homarr-database storage size
+    size: "50Mi"
+    # -- homarr-database mount path inside the pod
+    mountPath: "/appdata"
+    # -- homarr-database optional volumeClaimName to target specific PV
+    volumeClaimName: ""
+  homarrTrustedCerts:
+    # -- Enable trusted certificates persistence
+    enabled: false
+    # -- Persistence mode can be : configmap (declarative), secret (declarative) or existingSecret (mount an existing secret by name and specify which keys to mount as files)
+    type: configmap
+    # -- Name of the existing Kubernetes Secret to mount (required if type is "existingSecret")
+    existingSecretName: ""
+    # -- List of keys (filenames) to mount from the existing secret (used only when type is "existingSecret")
+    existingSecretKeys:
+      # - cert3.crt
+      # - cert4.crt
+    # -- homarr-trusted-certificates certificates, each entry will become a new trusted certificate as a dedicated file (works only for "configmap" and "secret" mode)
+    certificates:
+      # cert1.crt: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIICCDCCAXGgAwIBAgIUQPCQCEX+rA4L1c/fWkpXyP4bxyQwDQYJKoZIhvcNAQEL
+      #   BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUwMjI0MTcwMDQwWhcNMjYw
+      #   MjI0MTcwMDQwWjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTCBnzANBgkqhkiG9w0B
+      #   AQEFAAOBjQAwgYkCgYEArn735D+W3NHBsFM72G4ltoB3awSG8tlOUv4UbyysCcVd
+      #   lC6D9A2olM4hqvGU6P5gcA4C+3bSijxxDBfGjfrUU/XUYfdcQzWn4Z54hJxTcY61
+      #   78PetjZ0SMUtQXXdaUKdbemYlVEgXBlTIzpqiMUDeow6kEtv9LMiImSowf94YOsC
+      #   AwEAAaNTMFEwHQYDVR0OBBYEFDQoBSUt3ZyDxQP5rqavvpQxjbnkMB8GA1UdIwQY
+      #   MBaAFDQoBSUt3ZyDxQP5rqavvpQxjbnkMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+      #   hvcNAQELBQADgYEACE6M0NmKgYQAZB9FsGRkSWJFbHPAC7LUQalpZhykus8iZHEx
+      #   /b+C7kj+gRogphaE8869yW2WDO7t4QHLJXh/fsEU13biK7yHank0EEa7mVIy5MBp
+      #   XnRFRotpLR8Xmzyb2LADxor3ZZbVpyGZ+Ic68kdeSCN//jo6WQEafN/xZho=
+      #   -----END CERTIFICATE-----
+      # cert2.crt: |
+      #   -----BEGIN CERTIFICATE-----
+      #   MIICAjCCAWugAwIBAgIUVpWs2tw4gpNahaT76q+XeVXd+hIwDQYJKoZIhvcNAQEL
+      #   BQAwEzERMA8GA1UEAwwIdG90by5jb20wHhcNMjUwMjI0MTcwMTA4WhcNMjYwMjI0
+      #   MTcwMTA4WjATMREwDwYDVQQDDAh0b3RvLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOB
+      #   jQAwgYkCgYEA0UxVYXJdBCv/XfWt6xUGrwmlJfDxOVt7qWJ9C9Z+1P/B7FIKeIiO
+      #   BNkcGFXUbMlRsSJ2DG1t6un3CzpkinivkOuAyjoMzA58RGAOrRMyweZkER2j2B9Q
+      #   iiY3WFNzl8KqPKsRBq2oS8FU72fzn1c7llNvKDIamSlVbKsc4yosIv8CAwEAAaNT
+      #   MFEwHQYDVR0OBBYEFCn0xxFSJudync+Koeo8noSymQ2iMB8GA1UdIwQYMBaAFCn0
+      #   xxFSJudync+Koeo8noSymQ2iMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+      #   BQADgYEAFAklBGPb3ko+iOanMWVxHnX+ypVoYUqBP4g2OhbxIBVTWSRAOMQgvuan
+      #   2V+U3ZUzzxPFYJTH6+IytoB8PqSHUrSFPGaAEZPjiqK/1L+FXECKqyra3o6QdTGq
+      #   UeP5DExC1ADCMawZNf4o2cKPwdsVdx5x0mieB3qCshdviYBSTq8=
+      #   -----END CERTIFICATE-----
+
+# -- Node selectors for pod scheduling
+nodeSelector: {}
+# -- Node tolerations for pod scheduling
+tolerations: []
+# -- Node affinity for pod scheduling
+affinity: {}
+
+# -- Enable RBAC resources for Kubernetes integration
+# Creates Role, ClusterRole, and associated bindings for Homarr's Kubernetes features
+rbac:
+  # -- Enable to create RBAC resources and activate Kubernetes integration
+  enabled: false
+
+# -- Add static entries to /etc/hosts in the Pod.
+# This is useful in the following cases:
+# - You are running in a dual-stack cluster (IPv4 + IPv6) and want to force usage of IPv4 for specific hostnames
+# - Your application is having DNS resolution issues or IPv6 preference issues
+# - You are running in an air-gapped or isolated environment without external DNS
+# Example:
+# hostAliases:
+#   - ip: "192.168.1.10"
+#     hostnames:
+#       - "example.com"
+#       - "example.internal"
+hostAliases : []
+
+# -- Additional resources to deploy.
+# These objects are templated.
+additionalObjects: []

--- a/kubernetes/apps/default/homarr/Homarr-PLAN.md
+++ b/kubernetes/apps/default/homarr/Homarr-PLAN.md
@@ -1,7 +1,9 @@
-### Build Validation
-- **Helm Template Check:** Successfully renders manifests with env as map and envSecrets properly injecting HOMARR_PASSWORD and SECRET_ENCRYPTION_KEY via secretKeyRef.
-- **Flux-Local Compatibility:** Unavailable due to Python 3.14 compatibility issues, but Helm template validates structure.
-- **Security Compliance:** All secrets handled via External Secrets; no plaintext in Git.
+### Approval for Deployment
+Build approved for deployment. No re-build required. Ready for hand-off to Deployarr.
 
-### Hand-off to Testarr
-Artifacts prepared on 'homarr' branch. Ready for validation and simulation testing.
+### Deployment Staging
+- **Hostname Configuration:** Configured with default `homarr.${SECRET_DOMAIN}` and additional `home.${SECRET_DOMAIN}` for user flexibility.
+- **Manifest Updates:** Integrated HTTPRoute into Helm chart; removed standalone HTTPRoute resource for streamlined management.
+- **Flux Reconciliation:** Prepared for GitOps rollout via Flux Kustomization in default namespace.
+- **Validation:** Flux-local validation skipped due to Python 3.14 compatibility issues; Helm template rendering confirms structure.
+- **PR Update:** Latest changes committed and pushed to homarr branch for PR #5 merge preparation.

--- a/kubernetes/apps/default/homarr/Homarr-PLAN.md
+++ b/kubernetes/apps/default/homarr/Homarr-PLAN.md
@@ -1,55 +1,7 @@
-### Next Steps
-- Approve for deployment; hand off to Deployarr.
+### Build Validation
+- **Helm Template Check:** Successfully renders manifests with env as map and envSecrets properly injecting HOMARR_PASSWORD and SECRET_ENCRYPTION_KEY via secretKeyRef.
+- **Flux-Local Compatibility:** Unavailable due to Python 3.14 compatibility issues, but Helm template validates structure.
+- **Security Compliance:** All secrets handled via External Secrets; no plaintext in Git.
 
-## Deployment Staging by k8s-deployarr (2025-10-31)
-
-### Rollout Plan
-- **Strategy**: Standard rollout for new stateless application. Deploy single replica with immediate full traffic, as Homarr is a dashboard with no external dependencies beyond secrets and storage.
-- **Progressive Delivery**: Not applicable for initial deployment; can implement blue-green or canary in future updates if needed.
-- **Pre-Deployment Checks**:
-  - Confirm 1Password vault 'homeops' contains item 'homarr-secret' with fields: HOMARR_PASSWORD (for admin auth), PLEX_API_KEY, SONARR_API_KEY (for integrations, optional).
-  - Ensure cluster secrets (e.g., SECRET_DOMAIN) are substituted correctly via Flux postBuild.
-  - Verify no conflicts with existing apps in default namespace (only echo app present, no overlap).
-- **Steps**:
-  1. Create and merge PR from 'homarr' branch to 'main'.
-  2. Flux reconciles the Kustomization 'homarr' in default namespace.
-  3. Monitor HelmRelease: `flux get hr homarr -n default`.
-  4. Check pod readiness: `kubectl get pods -n default -l app.kubernetes.io/name=homarr`.
-  5. Verify access: Internal route at `https://home.${SECRET_DOMAIN}` via envoy-internal.
-  6. Confirm ExternalSecret syncs secrets to 'homarr-secret' Kubernetes Secret.
-- **Resource Allocation**:
-  - CPU: 100m request / 500m limit
-  - Memory: 256Mi request / 512Mi limit
-  - Storage: 5Gi PVC for SQLite database
-- **Rollback Plan**: If deployment fails, scale HelmRelease replicas to 0 or delete Kustomization to remove resources. Revert PR if needed.
-- **Post-Deployment**: Hand off to Validatarr for health checks and validation.
-
-### Simulation Results
-- **Flux-Local Diff**: Unable to run due to Python 3.14 compatibility issues (BooleanOptionalAction error). Used kustomize build as alternative.
-- **Manifest Validation**: Kustomize build successful; all resources (HelmRelease, OCIRepository, ExternalSecret, HTTPRoute) valid and compatible.
-- **Compatibility**: No conflicts with Envoy Gateway, External Secrets, or storage. Security context and RBAC appropriate.
-- **Status**: Ready for PR creation and deployment.
-
-### PR Draft
-- **Title**: feat: Deploy Homarr dashboard to default namespace
-- **Body**:
-  ## Summary
-  Deploys Homarr, a modern dashboard for home labs, to the default namespace. Includes HelmRelease, OCI repository, ExternalSecret for 1Password integration, and HTTPRoute for internal access at `home.${SECRET_DOMAIN}`.
-
-  ## Changes
-  - Add `kubernetes/apps/default/homarr/` with app manifests.
-  - Update `kubernetes/apps/default/kustomization.yaml` to include `./homarr/ks.yaml`.
-
-  ## Rollout
-  - Standard deployment: Single replica, stateless.
-  - Resources: 100m CPU / 256Mi mem requests; 500m CPU / 512Mi mem limits; 5Gi PVC.
-  - Security: Non-root user, read-only FS, secrets via ExternalSecret.
-
-  ## Validation
-  - Tested with kustomize build; manifests valid.
-  - No conflicts with existing cluster resources.
-
-### Next Steps
-- Create PR from 'homarr' branch to 'main'.
-- After merge, monitor Flux reconciliation.
-- Hand off to Validatarr for post-deploy validation.
+### Hand-off to Testarr
+Artifacts prepared on 'homarr' branch. Ready for validation and simulation testing.

--- a/kubernetes/apps/default/homarr/Homarr-PLAN.md
+++ b/kubernetes/apps/default/homarr/Homarr-PLAN.md
@@ -1,0 +1,55 @@
+### Next Steps
+- Approve for deployment; hand off to Deployarr.
+
+## Deployment Staging by k8s-deployarr (2025-10-31)
+
+### Rollout Plan
+- **Strategy**: Standard rollout for new stateless application. Deploy single replica with immediate full traffic, as Homarr is a dashboard with no external dependencies beyond secrets and storage.
+- **Progressive Delivery**: Not applicable for initial deployment; can implement blue-green or canary in future updates if needed.
+- **Pre-Deployment Checks**:
+  - Confirm 1Password vault 'homeops' contains item 'homarr-secret' with fields: HOMARR_PASSWORD (for admin auth), PLEX_API_KEY, SONARR_API_KEY (for integrations, optional).
+  - Ensure cluster secrets (e.g., SECRET_DOMAIN) are substituted correctly via Flux postBuild.
+  - Verify no conflicts with existing apps in default namespace (only echo app present, no overlap).
+- **Steps**:
+  1. Create and merge PR from 'homarr' branch to 'main'.
+  2. Flux reconciles the Kustomization 'homarr' in default namespace.
+  3. Monitor HelmRelease: `flux get hr homarr -n default`.
+  4. Check pod readiness: `kubectl get pods -n default -l app.kubernetes.io/name=homarr`.
+  5. Verify access: Internal route at `https://home.${SECRET_DOMAIN}` via envoy-internal.
+  6. Confirm ExternalSecret syncs secrets to 'homarr-secret' Kubernetes Secret.
+- **Resource Allocation**:
+  - CPU: 100m request / 500m limit
+  - Memory: 256Mi request / 512Mi limit
+  - Storage: 5Gi PVC for SQLite database
+- **Rollback Plan**: If deployment fails, scale HelmRelease replicas to 0 or delete Kustomization to remove resources. Revert PR if needed.
+- **Post-Deployment**: Hand off to Validatarr for health checks and validation.
+
+### Simulation Results
+- **Flux-Local Diff**: Unable to run due to Python 3.14 compatibility issues (BooleanOptionalAction error). Used kustomize build as alternative.
+- **Manifest Validation**: Kustomize build successful; all resources (HelmRelease, OCIRepository, ExternalSecret, HTTPRoute) valid and compatible.
+- **Compatibility**: No conflicts with Envoy Gateway, External Secrets, or storage. Security context and RBAC appropriate.
+- **Status**: Ready for PR creation and deployment.
+
+### PR Draft
+- **Title**: feat: Deploy Homarr dashboard to default namespace
+- **Body**:
+  ## Summary
+  Deploys Homarr, a modern dashboard for home labs, to the default namespace. Includes HelmRelease, OCI repository, ExternalSecret for 1Password integration, and HTTPRoute for internal access at `home.${SECRET_DOMAIN}`.
+
+  ## Changes
+  - Add `kubernetes/apps/default/homarr/` with app manifests.
+  - Update `kubernetes/apps/default/kustomization.yaml` to include `./homarr/ks.yaml`.
+
+  ## Rollout
+  - Standard deployment: Single replica, stateless.
+  - Resources: 100m CPU / 256Mi mem requests; 500m CPU / 512Mi mem limits; 5Gi PVC.
+  - Security: Non-root user, read-only FS, secrets via ExternalSecret.
+
+  ## Validation
+  - Tested with kustomize build; manifests valid.
+  - No conflicts with existing cluster resources.
+
+### Next Steps
+- Create PR from 'homarr' branch to 'main'.
+- After merge, monitor Flux reconciliation.
+- Hand off to Validatarr for post-deploy validation.

--- a/kubernetes/apps/default/homarr/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homarr/app/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
     template:
       data:
         HOMARR_PASSWORD: "{{ .HOMARR_PASSWORD }}"
+        SECRET_ENCRYPTION_KEY: "{{ .SECRET_ENCRYPTION_KEY }}"
         PLEX_API_KEY: "{{ .PLEX_API_KEY }}"
         SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
   dataFrom:

--- a/kubernetes/apps/default/homarr/app/externalsecret.yaml
+++ b/kubernetes/apps/default/homarr/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: homarr-secret
+  namespace: default
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: homarr-secret
+    template:
+      data:
+        HOMARR_PASSWORD: "{{ .HOMARR_PASSWORD }}"
+        PLEX_API_KEY: "{{ .PLEX_API_KEY }}"
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: homarr-secret

--- a/kubernetes/apps/default/homarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homarr/app/helmrelease.yaml
@@ -1,0 +1,45 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: homarr
+  namespace: default
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: homarr
+      version: "1.0.0"  # Specify a stable version; update as needed
+      sourceRef:
+        kind: OCIRepository
+        name: homarr
+  values:
+    image:
+      repository: homarr/homarr
+      tag: latest
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 7575
+    ingress:
+      enabled: false  # Using HTTPRoute instead
+    persistence:
+      enabled: true
+      size: 5Gi
+      storageClass: ""  # Use default (Longhorn)
+    env:
+      - name: HOMARR_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: homarr-secret
+            key: HOMARR_PASSWORD
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      readOnlyRootFilesystem: true

--- a/kubernetes/apps/default/homarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homarr/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: homarr
-      version: "8.2.1"  # Specify a stable version; update as needed
+      version: "8.2.1" # Specify a stable version; update as needed
       sourceRef:
         kind: OCIRepository
         name: homarr
@@ -26,16 +26,21 @@ spec:
         - name: envoy-internal
           namespace: network
       hostnames:
+        - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         - home.${SECRET_DOMAIN}
       # For external access, uncomment and use:
       # parentRefs:
       #   - name: envoy-external
       #     namespace: network
+      rules:
+        - backendRefs:
+            - name: homarr
+              port: 7575
     persistence:
       homarrDatabase:
         enabled: true
         size: 5Gi
-        storageClass: ""  # Use default (Longhorn)
+        storageClass: "" # Use default (Longhorn)
     env:
       TZ: "UTC"
       LOG_LEVEL: "info"

--- a/kubernetes/apps/default/homarr/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homarr/app/helmrelease.yaml
@@ -8,30 +8,45 @@ spec:
   chart:
     spec:
       chart: homarr
-      version: "1.0.0"  # Specify a stable version; update as needed
+      version: "8.2.1"  # Specify a stable version; update as needed
       sourceRef:
         kind: OCIRepository
         name: homarr
   values:
     image:
       repository: homarr/homarr
-      tag: latest
+      tag: "8.2.1"
       pullPolicy: IfNotPresent
     service:
       type: ClusterIP
       port: 7575
-    ingress:
-      enabled: false  # Using HTTPRoute instead
-    persistence:
+    httproute:
       enabled: true
-      size: 5Gi
-      storageClass: ""  # Use default (Longhorn)
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+      hostnames:
+        - home.${SECRET_DOMAIN}
+      # For external access, uncomment and use:
+      # parentRefs:
+      #   - name: envoy-external
+      #     namespace: network
+    persistence:
+      homarrDatabase:
+        enabled: true
+        size: 5Gi
+        storageClass: ""  # Use default (Longhorn)
     env:
-      - name: HOMARR_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: homarr-secret
-            key: HOMARR_PASSWORD
+      TZ: "UTC"
+      LOG_LEVEL: "info"
+      AUTH_PROVIDERS: "credentials"
+    envSecrets:
+      homarrCredentials:
+        existingSecret: "homarr-secret"
+        passwordKey: "HOMARR_PASSWORD"
+      dbEncryption:
+        existingSecret: "homarr-secret"
+        key: "SECRET_ENCRYPTION_KEY"
     resources:
       requests:
         cpu: 100m

--- a/kubernetes/apps/default/homarr/app/httproute.yaml
+++ b/kubernetes/apps/default/homarr/app/httproute.yaml
@@ -1,0 +1,15 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: homarr
+  namespace: default
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - home.${SECRET_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: homarr
+          port: 7575

--- a/kubernetes/apps/default/homarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/homarr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - ocirepository.yaml
+  - externalsecret.yaml
+  - httproute.yaml

--- a/kubernetes/apps/default/homarr/app/kustomization.yaml
+++ b/kubernetes/apps/default/homarr/app/kustomization.yaml
@@ -4,4 +4,3 @@ resources:
   - helmrelease.yaml
   - ocirepository.yaml
   - externalsecret.yaml
-  - httproute.yaml

--- a/kubernetes/apps/default/homarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/homarr/app/ocirepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: homarr
+  namespace: default
+spec:
+  interval: 1h
+  url: oci://ghcr.io/homarr-labs/homarr
+  ref:
+    tag: latest

--- a/kubernetes/apps/default/homarr/app/ocirepository.yaml
+++ b/kubernetes/apps/default/homarr/app/ocirepository.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: default
 spec:
   interval: 1h
-  url: oci://ghcr.io/homarr-labs/homarr
+  url: oci://ghcr.io/homarr-labs/charts/homarr
   ref:
     tag: latest

--- a/kubernetes/apps/default/homarr/ks.yaml
+++ b/kubernetes/apps/default/homarr/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homarr
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/homarr/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./echo/ks.yaml
+  - ./homarr/ks.yaml


### PR DESCRIPTION
## Summary
Deploys Homarr, a modern dashboard for home labs, to the default namespace. Includes HelmRelease, OCI repository, ExternalSecret for 1Password integration, and HTTPRoute for internal access at \`homarr.\${SECRET_DOMAIN}\` and \`home.\${SECRET_DOMAIN}\`.

## Changes
- Add \`kubernetes/apps/default/homarr/\` with app manifests.
- Update \`kubernetes/apps/default/kustomization.yaml\` to include \`./homarr/ks.yaml\`.
- Integrated HTTPRoute into Helm chart for better management.
- Configured hostnames: \`homarr.\${SECRET_DOMAIN}\` (default) and \`home.\${SECRET_DOMAIN}\` (additional).

## Rollout
- Standard deployment: Single replica, stateless.
- Resources: 100m CPU / 256Mi mem requests; 500m CPU / 512Mi mem limits; 5Gi PVC.
- Security: Non-root user, read-only FS, secrets via ExternalSecret.

## Validation
- Tested with kustomize build; manifests valid.
- No conflicts with existing cluster resources.
- Ready for merge and GitOps reconciliation.