### PR TITLE
feat: add home assistant ecosystem to home namespace

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-assistant
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: home-assistant
+  interval: 1h
+  values:
+    controllers:
+      home-assistant:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-assistant/home-assistant
+              tag: stable
+            env:
+              TZ: America/New_York
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8123
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8123
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+          code-server:
+            image:
+              repository: ghcr.io/coder/code-server
+              tag: 4.96.4
+            args:
+              - --auth
+              - none
+              - --user-data-dir
+              - /config/.vscode
+              - --extensions-dir
+              - /config/.vscode
+              - --port
+              - "8081"
+              - /config
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 0      # HA needs root for some integrations
+        runAsGroup: 0
+        fsGroup: 0
+
+    # Uncomment and set hostname when USB devices are attached
+    # defaultPodOptions:
+    #   nodeSelector:
+    #     kubernetes.io/hostname: <node-with-usb>
+
+    service:
+      app:
+        controller: home-assistant
+        ports:
+          http:
+            port: 8123
+      code-server:
+        controller: home-assistant
+        ports:
+          http:
+            port: 8081
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 25Gi
+        globalMounts:
+          - path: /config
+      # Uncomment for AlarmDecoder USB device
+      # alarmdecoder-usb:
+      #   type: hostPath
+      #   hostPath: /dev/serial/by-id/<alarmdecoder-device-id>
+      #   globalMounts:
+      #     - path: /dev/ttyUSB0
+
+    route:
+      app:
+        hostnames: ["hass.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8123
+      code-server:
+        hostnames: ["hass-code.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: code-server
+                port: 8081
+      # Uncomment for external access (via Cloudflare Tunnel)
+      # app-external:
+      #   hostnames: ["hass.${SECRET_DOMAIN}"]
+      #   parentRefs:
+      #     - name: envoy-external
+      #       namespace: network
+      #       sectionName: https
+      #   rules:
+      #     - backendRefs:
+      #         - identifier: app
+      #           port: 8123

--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/home-assistant/app/ocirepository.yaml
+++ b/kubernetes/apps/home/home-assistant/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-assistant
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: home-assistant
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/home-assistant/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false
+  dependsOn:
+    - name: mosquitto
+    - name: zwave-js-ui
+    - name: matter-server

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./mosquitto/ks.yaml
+  - ./zwave-js-ui/ks.yaml
+  - ./matter-server/ks.yaml
+  - ./home-assistant/ks.yaml
+  - ./samba/ks.yaml
+  - ./ttyd/ks.yaml

--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matter-server
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: matter-server
+  interval: 1h
+  values:
+    controllers:
+      matter-server:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-assistant-libs/python-matter-server
+              tag: 7.0.1
+            args:
+              - --storage-path
+              - /data
+              - --paa-root-cert-dir
+              - /data/credentials
+            env:
+              TZ: America/New_York
+            securityContext:
+              privileged: true  # Required for Matter
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+
+    defaultPodOptions:
+      hostNetwork: true  # Matter requires host networking
+
+    service:
+      app:
+        controller: matter-server
+        ports:
+          matter:
+            port: 5580
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/home/matter-server/app/kustomization.yaml
+++ b/kubernetes/apps/home/matter-server/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/matter-server/app/ocirepository.yaml
+++ b/kubernetes/apps/home/matter-server/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: matter-server
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: matter-server
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/matter-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mosquitto
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: mosquitto
+  interval: 1h
+  values:
+    controllers:
+      mosquitto:
+        containers:
+          app:
+            image:
+              repository: eclipse-mosquitto
+              tag: 2.0.21
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1883
+        runAsGroup: 1883
+        fsGroup: 1883
+
+    service:
+      app:
+        controller: mosquitto
+        ports:
+          mqtt:
+            port: 1883
+
+    persistence:
+      config:
+        type: configMap
+        name: mosquitto-config
+        globalMounts:
+          - path: /mosquitto/config/mosquitto.conf
+            subPath: mosquitto.conf
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /mosquitto/data
+
+    configMaps:
+      config:
+        data:
+          mosquitto.conf: |
+            listener 1883
+            allow_anonymous true
+            persistence true
+            persistence_location /mosquitto/data/

--- a/kubernetes/apps/home/mosquitto/app/kustomization.yaml
+++ b/kubernetes/apps/home/mosquitto/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/mosquitto/app/ocirepository.yaml
+++ b/kubernetes/apps/home/mosquitto/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mosquitto
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/mosquitto/ks.yaml
+++ b/kubernetes/apps/home/mosquitto/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mosquitto
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/mosquitto/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/namespace.yaml
+++ b/kubernetes/apps/home/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: home
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/home/samba/app/externalsecret.yaml
+++ b/kubernetes/apps/home/samba/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: samba
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: samba-secret
+    template:
+      data:
+        SAMBA_PASSWORD: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: samba

--- a/kubernetes/apps/home/samba/app/helmrelease.yaml
+++ b/kubernetes/apps/home/samba/app/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: samba
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: samba
+  interval: 1h
+  values:
+    controllers:
+      samba:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/crazy-max/samba
+              tag: 4.21.3
+            env:
+              TZ: America/New_York
+              SAMBA_WORKGROUP: WORKGROUP
+            envFrom:
+              - secretRef:
+                  name: samba-secret
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+
+    service:
+      app:
+        controller: samba
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "10.0.3.55"
+        ports:
+          smb:
+            port: 445
+
+    persistence:
+      ha-config:
+        existingClaim: home-assistant-config
+        globalMounts:
+          - path: /share/home-assistant
+      config:
+        type: configMap
+        name: samba-config
+        globalMounts:
+          - path: /data/config.yml
+            subPath: config.yml
+
+    configMaps:
+      config:
+        data:
+          config.yml: |
+            auth:
+              - user: homeassistant
+                group: homeassistant
+                uid: 0
+                gid: 0
+                password_file: /run/secrets/samba_password
+            share:
+              - name: home-assistant
+                path: /share/home-assistant
+                browsable: yes
+                readonly: no
+                guestok: no
+                validusers: homeassistant

--- a/kubernetes/apps/home/samba/app/kustomization.yaml
+++ b/kubernetes/apps/home/samba/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/home/samba/app/ocirepository.yaml
+++ b/kubernetes/apps/home/samba/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: samba
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/samba/ks.yaml
+++ b/kubernetes/apps/home/samba/ks.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: samba
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/samba/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false
+  dependsOn:
+    - name: home-assistant

--- a/kubernetes/apps/home/ttyd/app/helmrelease.yaml
+++ b/kubernetes/apps/home/ttyd/app/helmrelease.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ttyd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ttyd
+  interval: 1h
+  values:
+    controllers:
+      ttyd:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/tsl0922/ttyd
+              tag: 1.7.7
+            args:
+              - -W
+              - sh
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+
+    service:
+      app:
+        controller: ttyd
+        ports:
+          http:
+            port: 7681
+
+    route:
+      app:
+        hostnames: ["hass-terminal.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 7681

--- a/kubernetes/apps/home/ttyd/app/kustomization.yaml
+++ b/kubernetes/apps/home/ttyd/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/ttyd/app/ocirepository.yaml
+++ b/kubernetes/apps/home/ttyd/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ttyd
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/ttyd/ks.yaml
+++ b/kubernetes/apps/home/ttyd/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ttyd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/ttyd/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zwave-js-ui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: zwave-js-ui
+  interval: 1h
+  values:
+    controllers:
+      zwave-js-ui:
+        type: statefulset
+        containers:
+          app:
+            image:
+              repository: ghcr.io/zwave-js/zwave-js-ui
+              tag: 9.31.0
+            env:
+              TZ: America/New_York
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            # Uncomment for USB access
+            # securityContext:
+            #   privileged: true
+
+    # Uncomment and set hostname when USB device is attached
+    # defaultPodOptions:
+    #   nodeSelector:
+    #     kubernetes.io/hostname: <node-with-zwave>
+
+    service:
+      app:
+        controller: zwave-js-ui
+        ports:
+          http:
+            port: 8091
+          websocket:
+            port: 3000
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /usr/src/app/store
+      # Uncomment for Z-Wave USB device
+      # zwave-usb:
+      #   type: hostPath
+      #   hostPath: /dev/serial/by-id/<zwave-device-id>
+      #   globalMounts:
+      #     - path: /dev/zwave
+
+    route:
+      app:
+        hostnames: ["hass-zwave.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8091

--- a/kubernetes/apps/home/zwave-js-ui/app/kustomization.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/zwave-js-ui/app/ocirepository.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zwave-js-ui
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/zwave-js-ui/ks.yaml
+++ b/kubernetes/apps/home/zwave-js-ui/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: zwave-js-ui
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/zwave-js-ui/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false


### PR DESCRIPTION
Deploy complete Home Assistant stack with supporting services:
- Home Assistant with Code Server sidecar (hass., hass-code.)
- Mosquitto MQTT broker
- Z-Wave JS UI controller (hass-zwave.)
- Matter Server for Matter protocol support
- Samba for NFS access to HA config
- ttyd web terminal (hass-terminal.)

All services use BJW-S app-template chart with:
- Longhorn storage (25Gi for HA, 1Gi for supporting services)
- Internal gateway access via envoy-internal
- External route commented out for later activation
- USB device mounts commented out for later configuration

Required 1Password secret: samba (field: samba_password)