### PR TITLE
Add Tailscale Operator and Gateway for Tailnet connectivity

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -12,3 +12,5 @@ resources:
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./k8s-gateway/ks.yaml
+  - ./tailscale-operator/ks.yaml
+  - ./tailscale-gateway/ks.yaml

--- a/kubernetes/apps/network/tailscale-gateway/app/connector.yaml
+++ b/kubernetes/apps/network/tailscale-gateway/app/connector.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: cluster-gateway
+spec:
+  hostname: k8s-gateway
+  tags:
+    - tag:k8s
+  subnetRouter:
+    advertiseRoutes:
+      - "10.42.0.0/16"
+      - "10.43.0.0/16"
+      - "10.0.3.0/24"
+  exitNode: true

--- a/kubernetes/apps/network/tailscale-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/tailscale-gateway/app/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./connector.yaml

--- a/kubernetes/apps/network/tailscale-gateway/ks.yaml
+++ b/kubernetes/apps/network/tailscale-gateway/ks.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailscale-gateway
+spec:
+  dependsOn:
+    - name: tailscale-operator
+  interval: 1h
+  path: ./kubernetes/apps/network/tailscale-gateway/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/network/tailscale-operator/app/externalsecret.yaml
+++ b/kubernetes/apps/network/tailscale-operator/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-operator
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: operator-oauth
+    template:
+      data:
+        client_id: "{{ .oauth_client_id }}"
+        client_secret: "{{ .oauth_client_secret }}"
+  dataFrom:
+    - extract:
+        key: tailscale-operator

--- a/kubernetes/apps/network/tailscale-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale-operator/app/helmrelease.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+spec:
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: 1.80.3
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    operatorConfig:
+      defaultTags:
+        - tag:k8s

--- a/kubernetes/apps/network/tailscale-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/network/tailscale-operator/app/helmrepository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale
+spec:
+  interval: 1h
+  url: https://pkgs.tailscale.com/helmcharts

--- a/kubernetes/apps/network/tailscale-operator/app/kustomization.yaml
+++ b/kubernetes/apps/network/tailscale-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/network/tailscale-operator/ks.yaml
+++ b/kubernetes/apps/network/tailscale-operator/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tailscale-operator
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/network/tailscale-operator/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: true
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: tailscale-operator
+      namespace: network


### PR DESCRIPTION
## Summary
- Deploys Tailscale Operator via HelmRepository + HelmRelease
- Creates Connector CRD for subnet routing + exit node
- ExternalSecret for OAuth credentials from 1Password

## Prerequisites
- [x] Tailscale OAuth client created (Admin Console > Settings > OAuth clients)
- [x] 1Password item `tailscale-operator` with `client_id` and `client_secret`
- [x] ACL tags (`tag:k8s-operator`, `tag:k8s`) and autoApprovers configured

## Test plan
- [ ] `task validate` passes
- [ ] Operator pod running: `kubectl get pods -n network -l app.kubernetes.io/name=tailscale-operator`
- [ ] Connector proxy pod running
- [ ] Device appears in Tailscale Admin Console
- [ ] Subnet routes advertised and approved