### PR TITLE
Add KMS (vlmcsd) to tools namespace

### DIFF
--- a/kubernetes/apps/tools/kms/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/kms/app/helmrelease.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kms
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kms
+  interval: 1h
+  values:
+    controllers:
+      kms:
+        containers:
+          app:
+            image:
+              repository: mikolatero/vlmcsd
+              tag: latest
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 5m
+              limits:
+                memory: 16Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        type: LoadBalancer
+        controller: kms
+        ports:
+          kms:
+            port: 1688
+            protocol: TCP

--- a/kubernetes/apps/tools/kms/app/kustomization.yaml
+++ b/kubernetes/apps/tools/kms/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/tools/kms/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/kms/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kms
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/kms/ks.yaml
+++ b/kubernetes/apps/tools/kms/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kms
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/kms/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -8,3 +8,4 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./kms/ks.yaml


### PR DESCRIPTION
## Summary
- Deploys vlmcsd KMS emulator in `tools` namespace
- LoadBalancer service on TCP/1688
- No secrets, no storage, minimal resources (5m CPU / 16Mi RAM)

## Dependencies
- Requires namespaces PR merged first

## Test plan
- [ ] `task validate` passes
- [ ] Pod running: `kubectl get pods -n tools`
- [ ] Service has external IP: `kubectl get svc -n tools`