### PR TITLE
Add Gatus status monitoring to monitoring namespace

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gatus-config
+data:
+  config.yaml: |
+    storage:
+      type: sqlite
+      path: /data/data.db
+
+    ui:
+      title: Status | Home Ops
+      header: Status
+
+    endpoints:
+      - name: Gateway (Internal)
+        group: infrastructure
+        url: "https://echo.${SECRET_DOMAIN}"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+
+      - name: Cloudflare
+        group: external
+        url: "https://1.1.1.1/cdn-cgi/trace"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 1000"
+
+      - name: Google
+        group: external
+        url: "https://www.google.com"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 1000"

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gatus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gatus
+  interval: 1h
+  values:
+    controllers:
+      gatus:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/twin/gatus
+              tag: v5.34.0
+            env:
+              TZ: America/New_York
+              GATUS_CONFIG_PATH: /config
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        controller: gatus
+        ports:
+          http:
+            port: *port
+    persistence:
+      config:
+        type: configMap
+        name: gatus-config
+        globalMounts:
+          - path: /config/config.yaml
+            subPath: config.yaml
+            readOnly: true
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /data
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/monitoring/gatus/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gatus
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/monitoring/gatus/ks.yaml
+++ b/kubernetes/apps/monitoring/gatus/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gatus
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/gatus/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -8,3 +8,4 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./gatus/ks.yaml


### PR DESCRIPTION
## Summary
- Deploys Gatus endpoint monitoring in `monitoring` namespace
- ConfigMap with initial monitoring endpoints
- 1Gi Longhorn PVC for SQLite persistence
- Route via envoy-internal

## Dependencies
- Requires namespaces PR merged first

## Test plan
- [ ] `task validate` passes
- [ ] Pod running: `kubectl get pods -n monitoring`
- [ ] UI accessible at `gatus.${SECRET_DOMAIN}`