### PR TITLE
Add MeTube YouTube downloader to media namespace

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,3 +8,4 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./metube/ks.yaml

--- a/kubernetes/apps/media/metube/app/helmrelease.yaml
+++ b/kubernetes/apps/media/metube/app/helmrelease.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metube
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: metube
+  interval: 1h
+  values:
+    controllers:
+      metube:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/alexta69/metube
+              tag: "2025.01.06"
+            env:
+              TZ: America/New_York
+              DEFAULT_THEME: auto
+              DOWNLOAD_DIR: /downloads
+              STATE_DIR: /downloads/.metube
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8081
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: metube
+        ports:
+          http:
+            port: *port
+    persistence:
+      downloads:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        globalMounts:
+          - path: /downloads
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/media/metube/app/kustomization.yaml
+++ b/kubernetes/apps/media/metube/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/metube/app/ocirepository.yaml
+++ b/kubernetes/apps/media/metube/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metube
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/metube/ks.yaml
+++ b/kubernetes/apps/media/metube/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: metube
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/metube/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false


### PR DESCRIPTION
## Summary
- Deploys MeTube in `media` namespace
- Longhorn temp storage (will switch to NFS in Phase 3)
- Route via envoy-internal

## Dependencies
- Requires namespaces PR merged first

## Test plan
- [ ] `task validate` passes
- [ ] Pod running: `kubectl get pods -n media`
- [ ] UI accessible at `metube.${SECRET_DOMAIN}`