### PR TITLE
feat(monitoring): configure Authentik OIDC for Gatus and Grafana

### DIFF
--- a/.claude/commands/create-1p-secret.md
+++ b/.claude/commands/create-1p-secret.md
@@ -1,0 +1,170 @@
+---
+description: Create 1Password secret items for Kubernetes app deployments in the homeops vault
+allowed-tools: Bash(op item get:*), Bash(op item create:*), Bash(op item list:*), Bash(op generate password:*), Bash(op vault list:*)
+---
+
+Create a 1Password secret item for a Kubernetes application deployment.
+
+## Context
+
+This cluster uses External Secrets Operator with 1Password Connect. All app secrets are stored in the `homeops` vault. Secret items follow a naming convention of `<app-name>` and each field maps to a Kubernetes secret key.
+
+The cluster's ExternalSecret resources reference items by their title in 1Password, and field names map to secret data keys using snake_case.
+
+## Default Password Parameters
+
+Unless the user specifies otherwise, all generated passwords use:
+- Length: **30 characters**
+- Character set: uppercase letters, lowercase letters, digits, symbols
+- `op generate password --length 30 --uppercase --lowercase --digits --symbols`
+
+For apps that can't handle special characters (e.g., SABnzbd API keys), use:
+- `op generate password --length 32 --uppercase --lowercase --digits`
+
+For high-security fields (encryption keys, signing secrets, JWT secrets):
+- `op generate password --length 64 --uppercase --lowercase --digits --symbols`
+
+## Step 1: Verify 1Password CLI auth
+
+```bash
+op account list
+```
+
+If this fails or shows no accounts, tell the user to run `eval $(op signin)` in their terminal and retry. If it succeeds, proceed.
+
+Try a quick test:
+```bash
+op vault list 2>&1
+```
+
+If this returns an authorization error or hangs, inform the user that 1Password requires interactive authentication and they should run the command from their terminal directly.
+
+## Step 2: Parse the request
+
+The user will provide one of:
+- `app=<name>` — the app name (becomes the 1Password item title)
+- `fields=<field1>,<field2>,...` — fields to create
+- `vault=<name>` — optional vault override (default: `homeops`)
+- `no-symbols` — flag to generate passwords without special characters
+- `force` — overwrite if item already exists
+
+If the user just says something like "create secrets for gatus with fields oidc_client_id and oidc_client_secret", extract:
+- `app=gatus`
+- `fields=oidc_client_id,oidc_client_secret`
+
+## Step 3: Check if item already exists
+
+```bash
+op item get "<app-name>" --vault homeops 2>&1
+```
+
+If the item exists and `force` was not specified, list its current fields and ask the user whether to overwrite, add fields, or skip.
+
+## Step 4: Determine field types and generate values
+
+For each field, decide the type and generation strategy based on the field name:
+
+| Field name pattern | Type | Generation |
+|-------------------|------|------------|
+| `*_password`, `*_pass` | `password` | 30 chars, all character types |
+| `*_secret`, `*_key` (non-API) | `password` | 64 chars, all character types |
+| `*_api_key`, `*api*key*` | `password` | 32 chars, no symbols |
+| `*_id`, `*client_id` | `text` | Manual input required — client IDs are assigned by the identity provider, not generated |
+| `*_token` | `password` | 64 chars, no symbols |
+| `plex_claim` | `text` | Manual only — expires in 4 min, must come from https://plex.tv/claim |
+| `*_username`, `*_user` | `text` | Manual input required |
+| `*_url`, `*_host`, `*_endpoint` | `text` | Manual input required |
+| `*_license*` | `text` | Manual input required |
+
+Fields requiring manual input: prompt the user to provide values, or create the item with placeholder text `REPLACE_ME` and note it.
+
+**Exception for OIDC fields:** `oidc_client_id` and `oidc_client_secret` should BOTH be generated as passwords/text for now. The client_id can be a UUID (generate with `uuidgen | tr '[:upper:]' '[:lower:]'`) and the client_secret as a 64-char password. These will be used when creating the Authentik OIDC provider — Authentik accepts client_id/secret that you supply.
+
+## Step 5: Create the item
+
+Build the `op item create` command:
+
+```bash
+op item create \
+  --vault homeops \
+  --category login \
+  --title "<app-name>" \
+  "field1[type]=value1" \
+  "field2[type]=value2"
+```
+
+For fields with generated passwords, pipe through `op generate password`:
+
+```bash
+# Example for gatus
+CLIENT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+CLIENT_SECRET=$(op generate password --length 64 --uppercase --lowercase --digits --symbols)
+
+op item create \
+  --vault homeops \
+  --category login \
+  --title "gatus" \
+  "oidc_client_id[text]=${CLIENT_ID}" \
+  "oidc_client_secret[password]=${CLIENT_SECRET}"
+```
+
+## Step 6: Retrieve and display the created item
+
+After creation, fetch the item back and display all field values:
+
+```bash
+op item get "<app-name>" --vault homeops --format json | \
+  python3 -c "
+import sys, json
+item = json.load(sys.stdin)
+print(f'Item: {item[\"title\"]}')
+print(f'ID: {item[\"id\"]}')
+print()
+for f in item.get('fields', []):
+    if f.get('value') and f['purpose'] != 'USERNAME':
+        print(f'  {f[\"label\"]}: {f[\"value\"]}')
+"
+```
+
+## Step 7: Output Kubernetes manifest snippets
+
+After creating the item, output the corresponding ExternalSecret manifest snippet:
+
+```yaml
+# ExternalSecret template for <app-name>
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: <app-name>
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: <app-name>-secret
+    template:
+      data:
+        # Map field names to Kubernetes secret keys:
+        FIELD_NAME: "{{ .<field_name> }}"
+  dataFrom:
+    - extract:
+        key: <app-name>
+```
+
+Also output the HelmRelease envFrom snippet:
+```yaml
+# In HelmRelease values:
+envFrom:
+  - secretRef:
+      name: <app-name>-secret
+```
+
+## Notes
+
+- Never log or store secret values in files — display only in terminal output
+- The `homeops` vault is the default for all cluster apps
+- Items are titled exactly as `<app-name>` (lowercase, matching the Kubernetes app name)
+- Field names use snake_case matching what the ExternalSecret `.template.data` references
+- After running this command, also run `/setup-authentik-oidc` if the app uses OIDC

--- a/.claude/commands/setup-authentik-oidc.md
+++ b/.claude/commands/setup-authentik-oidc.md
@@ -1,0 +1,295 @@
+---
+description: Set up Authentik OIDC OAuth2 provider and application for a cluster app, create secrets, and update Kubernetes manifests
+allowed-tools: Bash(curl:*), Bash(kubectl:*), Bash(op item get:*), Bash(op item edit:*), Bash(cat:*)
+---
+
+Configure Authentik OIDC authentication for a new cluster application. This creates the OAuth2 Provider and Application in Authentik, stores credentials in 1Password, creates/updates ExternalSecret manifests, and updates the HelmRelease with OIDC config.
+
+## Cluster Context
+
+- **Authentik URL**: `https://auth.thegeekybits.com` (external) or `http://authentik.security.svc.cluster.local:9000` (internal)
+- **Domain**: `thegeekybits.com`
+- **Default gateway**: `envoy-internal` for internal apps, `envoy-external` for public apps
+- **Secret store**: 1Password vault `homeops`, ClusterSecretStore `onepassword-store`
+- **App namespace pattern**: app hostnames follow `<release-name>.thegeekybits.com`
+
+## Step 1: Gather required information
+
+Ask the user for (or infer from context/manifests):
+- `APP_NAME` — the app's Kubernetes release name (e.g., `gatus`, `grafana`)
+- `NAMESPACE` — the app's namespace (e.g., `monitoring`, `tools`)
+- `AUTH_METHOD` — `native_oidc` or `forward_auth` (most apps needing OIDC setup here use native_oidc)
+- `AUTHENTIK_TOKEN` — an Authentik API token (see Step 2)
+
+Infer hostname from the app's existing route in `kubernetes/apps/<namespace>/<app>/app/`:
+```bash
+grep -r "hostnames" kubernetes/apps/<namespace>/<app>/app/
+```
+Or from the deployed route:
+```bash
+KUBECONFIG="./kubeconfig" kubectl get httproute -n <namespace> <app> \
+  -o jsonpath='{.spec.hostnames[0]}' 2>/dev/null
+```
+
+## Step 2: Get or create Authentik API token
+
+Check 1Password for an existing token:
+```bash
+op item get "authentik" --vault homeops --fields label=api_token 2>/dev/null
+```
+
+If no token exists, instruct the user to:
+1. Log into Authentik at `https://auth.thegeekybits.com`
+2. Go to **Admin Interface** → **Directory** → **Tokens & App Passwords**
+3. Create a token with identifier `claude-api-token`, intent: **API**
+4. Copy the token key
+5. Run: `op item edit "authentik" --vault homeops "api_token[password]=<token>"`
+
+Store the token in variable `AUTHENTIK_TOKEN` for subsequent API calls.
+
+## Step 3: Determine OIDC redirect URI
+
+Based on the app type, the redirect URI follows these patterns:
+
+| App | Redirect URI Pattern |
+|-----|---------------------|
+| Gatus | `https://<hostname>/authorization-code/callback` |
+| Grafana | `https://<hostname>/login/generic_oauth` |
+| Forgejo | `https://<hostname>/user/oauth2/authentik/callback` |
+| OpenWebUI | `https://<hostname>/oauth/oidc/callback` |
+| BookLore | `https://<hostname>/api/auth/oidc/callback` |
+| Zipline | `https://<hostname>/api/auth/oauth/oidc` |
+| n8n | `https://<hostname>/rest/oauth2-credential/callback` |
+
+For unknown apps, check the app's documentation or use:
+`https://<hostname>/auth/callback` as a starting point and note it may need adjustment.
+
+## Step 4: Create the OAuth2 Provider in Authentik
+
+Use the Authentik API. The provider name follows `<APP_NAME>-provider` convention.
+
+First, get the authorization flow ID:
+```bash
+AUTH_FLOW=$(curl -s -H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+  "https://auth.thegeekybits.com/api/v3/flows/instances/?designation=authorization&slug=default-provider-authorization-implicit-consent" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['results'][0]['pk'])")
+```
+
+Get the invalidation flow ID:
+```bash
+INVAL_FLOW=$(curl -s -H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+  "https://auth.thegeekybits.com/api/v3/flows/instances/?designation=invalidation" \
+  | python3 -c "import sys,json; data=json.load(sys.stdin); print(data['results'][0]['pk']) if data['results'] else print('')")
+```
+
+Generate client credentials:
+```bash
+CLIENT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+CLIENT_SECRET=$(op generate password --length 64 --uppercase --lowercase --digits --symbols 2>/dev/null \
+  || openssl rand -base64 48 | tr -d '=' | head -c 64)
+```
+
+Create the provider:
+```bash
+PROVIDER_RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://auth.thegeekybits.com/api/v3/providers/oauth2/" \
+  -d "{
+    \"name\": \"${APP_NAME}-provider\",
+    \"client_type\": \"confidential\",
+    \"client_id\": \"${CLIENT_ID}\",
+    \"client_secret\": \"${CLIENT_SECRET}\",
+    \"redirect_uris\": \"${REDIRECT_URI}\",
+    \"authorization_flow\": \"${AUTH_FLOW}\",
+    \"sub_mode\": \"hashed_user_id\",
+    \"include_claims_in_id_token\": true,
+    \"signing_key\": null
+  }")
+
+PROVIDER_PK=$(echo "$PROVIDER_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['pk'])")
+echo "Created provider PK: $PROVIDER_PK"
+```
+
+## Step 5: Create the Authentik Application
+
+```bash
+APP_RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://auth.thegeekybits.com/api/v3/core/applications/" \
+  -d "{
+    \"name\": \"${APP_NAME}\",
+    \"slug\": \"${APP_NAME}\",
+    \"provider\": ${PROVIDER_PK},
+    \"meta_launch_url\": \"https://${HOSTNAME}\",
+    \"policy_engine_mode\": \"any\"
+  }")
+
+APP_SLUG=$(echo "$APP_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['slug'])")
+echo "Created application slug: $APP_SLUG"
+```
+
+If the application creation fails with a "slug already exists" error, the app already exists — update it instead:
+```bash
+curl -s -X PATCH \
+  -H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "https://auth.thegeekybits.com/api/v3/core/applications/${APP_SLUG}/" \
+  -d "{\"provider\": ${PROVIDER_PK}}"
+```
+
+## Step 6: Store credentials in 1Password
+
+Check if item already exists:
+```bash
+op item get "${APP_NAME}" --vault homeops 2>/dev/null | head -5
+```
+
+If item exists, add/update OIDC fields:
+```bash
+op item edit "${APP_NAME}" --vault homeops \
+  "oidc_client_id[text]=${CLIENT_ID}" \
+  "oidc_client_secret[password]=${CLIENT_SECRET}"
+```
+
+If item doesn't exist, create it:
+```bash
+op item create \
+  --vault homeops \
+  --category login \
+  --title "${APP_NAME}" \
+  "oidc_client_id[text]=${CLIENT_ID}" \
+  "oidc_client_secret[password]=${CLIENT_SECRET}"
+```
+
+## Step 7: Create or update ExternalSecret manifest
+
+Check if ExternalSecret already exists:
+```bash
+ls kubernetes/apps/${NAMESPACE}/${APP_NAME}/app/externalsecret.yaml 2>/dev/null
+```
+
+**If no ExternalSecret exists**, create `kubernetes/apps/${NAMESPACE}/${APP_NAME}/app/externalsecret.yaml`:
+
+```yaml
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ${APP_NAME}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: ${APP_NAME}-secret
+    template:
+      data:
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        key: ${APP_NAME}
+```
+
+Update `kubernetes/apps/${NAMESPACE}/${APP_NAME}/app/kustomization.yaml` to include:
+```yaml
+resources:
+  - ./externalsecret.yaml
+```
+
+**If ExternalSecret already exists**, add the OIDC fields to the template.data section.
+
+Also add `reloader.stakater.com/auto: "true"` to podAnnotations in the HelmRelease if not already present.
+
+## Step 8: Update the HelmRelease with OIDC config
+
+This step varies significantly by app. Apply the appropriate pattern:
+
+### Gatus (native OIDC)
+Add to `helmrelease.yaml` values under `controllers.gatus.containers.app.env`:
+```yaml
+OIDC_CLIENT_ID:
+  valueFrom:
+    secretKeyRef:
+      name: gatus-secret
+      key: OIDC_CLIENT_ID
+OIDC_CLIENT_SECRET:
+  valueFrom:
+    secretKeyRef:
+      name: gatus-secret
+      key: OIDC_CLIENT_SECRET
+```
+
+Add to `configmap.yaml` in the Gatus config YAML:
+```yaml
+security:
+  oidc:
+    issuer-url: https://auth.thegeekybits.com/application/o/gatus/
+    redirect-url: https://gatus.thegeekybits.com/authorization-code/callback
+    client-id: ${OIDC_CLIENT_ID}
+    client-secret: ${OIDC_CLIENT_SECRET}
+    scopes: [openid, email, profile]
+```
+
+### Grafana (native OAuth)
+Add to `helmrelease.yaml` in `grafana.ini` section:
+```yaml
+grafana.ini:
+  auth.generic_oauth:
+    enabled: true
+    name: Authentik
+    allow_sign_up: true
+    client_id: $__env{OIDC_CLIENT_ID}
+    client_secret: $__env{OIDC_CLIENT_SECRET}
+    scopes: openid email profile
+    auth_url: https://auth.thegeekybits.com/application/o/authorize/
+    token_url: https://auth.thegeekybits.com/application/o/token/
+    api_url: https://auth.thegeekybits.com/application/o/userinfo/
+    role_attribute_path: contains(groups[*], 'authentik Admins') && 'Admin' || 'Viewer'
+```
+
+Add `envFrom` in the HelmRelease:
+```yaml
+envFrom:
+  - secretRef:
+      name: grafana-secret
+```
+
+### Forward-auth apps (Sonarr, SABnzbd, etc.)
+Forward-auth is handled at the gateway level via Authentik's proxy provider — no changes needed to the app's HelmRelease. Instead, a separate `SecurityPolicy` or `AuthorizationPolicy` is applied to the HTTPRoute. Document this but don't modify the app manifest.
+
+## Step 9: Output summary
+
+Print a summary:
+```
+=== OIDC Setup Complete: <APP_NAME> ===
+
+Authentik Application:
+  Name: <APP_NAME>
+  Slug: <APP_NAME>
+  Launch URL: https://<hostname>
+
+OAuth2 Provider:
+  Name: <APP_NAME>-provider
+  Client ID: <client_id>
+  Redirect URI: <redirect_uri>
+  Discovery URL: https://auth.thegeekybits.com/application/o/<APP_NAME>/.well-known/openid-configuration
+
+1Password:
+  Vault: homeops
+  Item: <APP_NAME>
+  Fields: oidc_client_id, oidc_client_secret
+
+Manifests updated:
+  - kubernetes/apps/<namespace>/<app>/app/externalsecret.yaml (created/updated)
+  - kubernetes/apps/<namespace>/<app>/app/helmrelease.yaml (updated with OIDC config)
+  - kubernetes/apps/<namespace>/<app>/app/kustomization.yaml (updated if externalsecret added)
+
+Next steps:
+  1. git add + git commit the manifest changes
+  2. Push to remote and create PR
+  3. After Flux reconciles, test auth at https://<hostname>
+```

--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -9,6 +9,14 @@ data:
       type: sqlite
       path: /data/data.db
 
+    security:
+      oidc:
+        issuer-url: https://auth.thegeekybits.com/application/o/gatus/
+        redirect-url: https://gatus.thegeekybits.com/authorization-code/callback
+        client-id: "${OIDC_CLIENT_ID}"
+        client-secret: "${OIDC_CLIENT_SECRET}"
+        scopes: ["openid", "email", "profile"]
+
     ui:
       title: Status | Home Ops
       header: Status

--- a/kubernetes/apps/monitoring/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gatus
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: gatus-secret
+    template:
+      data:
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        key: gatus

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -19,6 +19,9 @@ spec:
             env:
               TZ: America/New_York
               GATUS_CONFIG_PATH: /config
+            envFrom:
+              - secretRef:
+                  name: gatus-secret
             probes:
               liveness: &probes
                 enabled: true
@@ -41,6 +44,8 @@ spec:
                 cpu: 10m
               limits:
                 memory: 128Mi
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./configmap.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: grafana-secret
+    template:
+      data:
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        admin_password: "{{ .admin_password }}"
+  dataFrom:
+    - extract:
+        key: grafana

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -13,6 +13,15 @@ spec:
     deploymentStrategy:
       type: Recreate
 
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    admin:
+      existingSecret: grafana-secret
+      passwordKey: admin_password
+
+    envFromSecret: grafana-secret
+
     grafana.ini:
       server:
         root_url: "https://grafana.${SECRET_DOMAIN}"
@@ -22,6 +31,17 @@ spec:
         reporting_enabled: false
       news:
         news_feed_enabled: false
+      auth.generic_oauth:
+        enabled: true
+        name: Authentik
+        allow_sign_up: true
+        client_id: $__env{OIDC_CLIENT_ID}
+        client_secret: $__env{OIDC_CLIENT_SECRET}
+        scopes: openid email profile
+        auth_url: https://auth.thegeekybits.com/application/o/authorize/
+        token_url: https://auth.thegeekybits.com/application/o/token/
+        api_url: https://auth.thegeekybits.com/application/o/userinfo/
+        role_attribute_path: contains(groups[*], 'authentik Admins') && 'Admin' || 'Viewer'
 
     persistence:
       enabled: true

--- a/kubernetes/apps/monitoring/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./httproute.yaml
+  - ./externalsecret.yaml


### PR DESCRIPTION
## Summary

- Add Authentik OIDC authentication to Gatus (native OIDC via configmap) and Grafana (generic OAuth via grafana.ini)
- Create ExternalSecret manifests for both apps pulling `oidc_client_id`, `oidc_client_secret` (and `admin_password` for Grafana) from 1Password `homeops` vault
- Add Stakater Reloader annotation to both deployments
- Add two new Claude Code project commands: `/create-1p-secret` and `/setup-authentik-oidc`

## Test plan

- [ ] Flux reconciles `monitoring` kustomization without errors
- [ ] ExternalSecrets sync: `kubectl get externalsecret -n monitoring`
- [ ] Gatus accessible at https://gatus.example.com — OIDC login redirects to Authentik
- [ ] Grafana accessible at https://grafana.example.com — "Sign in with Authentik" button present
- [ ] Grafana admin login works with stored admin password
- [ ] Authentik applications appear in app portal for both gatus and grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)
