### PR TITLE
fix(monitoring): correct OIDC config issues in Gatus and Grafana

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -13,8 +13,8 @@ data:
       oidc:
         issuer-url: https://auth.thegeekybits.com/application/o/gatus/
         redirect-url: https://gatus.thegeekybits.com/authorization-code/callback
-        client-id: "${OIDC_CLIENT_ID}"
-        client-secret: "${OIDC_CLIENT_SECRET}"
+        client-id: "$${OIDC_CLIENT_ID}"
+        client-secret: "$${OIDC_CLIENT_SECRET}"
         scopes: ["openid", "email", "profile"]
 
     ui:

--- a/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       data:
         OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
         OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        admin-user: "admin"
         admin_password: "{{ .admin_password }}"
   dataFrom:
     - extract:


### PR DESCRIPTION
## Summary

Fixes two issues introduced in #111 that caused both pods to crash:

- **Gatus**: `${OIDC_CLIENT_ID}` and `${OIDC_CLIENT_SECRET}` in the configmap were being consumed by Flux postBuild variable substitution (replaced with empty strings). Changed to `$${...}` so Flux passes them through as literals and Gatus resolves them from env at runtime.
- **Grafana**: Chart expects both `admin-user` and `admin_password` keys in `existingSecret`. Added `admin-user: "admin"` to the ExternalSecret template.

## Test plan

- [ ] `kubectl get pods -n monitoring` — both gatus and grafana reach Running
- [ ] `kubectl get externalsecret -n monitoring` — both show `SecretSynced: True`
- [ ] Gatus at https://gatus.example.com redirects to Authentik login
- [ ] Grafana at https://grafana.example.com shows "Sign in with Authentik"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
