### PR TITLE
fix(gatus): use Flux postBuild substitution for OIDC credentials

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -13,8 +13,8 @@ data:
       oidc:
         issuer-url: https://auth.thegeekybits.com/application/o/gatus/
         redirect-url: https://gatus.thegeekybits.com/authorization-code/callback
-        client-id: "$${OIDC_CLIENT_ID}"
-        client-secret: "$${OIDC_CLIENT_SECRET}"
+        client-id: "${OIDC_CLIENT_ID}"
+        client-secret: "${OIDC_CLIENT_SECRET}"
         scopes: ["openid", "email", "profile"]
 
     ui:

--- a/kubernetes/apps/monitoring/gatus/ks.yaml
+++ b/kubernetes/apps/monitoring/gatus/ks.yaml
@@ -10,6 +10,9 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+      - name: gatus-secret
+        kind: Secret
+        optional: true
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

Fixes the Gatus upgrade deadlock caused by a chicken-and-egg between the ConfigMap and the HelmRelease.

**Root cause:** The ConfigMap used `${OIDC_CLIENT_ID}` (Gatus env var syntax), which required the pod to have `envFrom` injecting the secret. But the HelmRelease was stuck in a rollback loop — Gatus crashed on startup (no env vars in the rolled-back v3 pod) → upgrade failed → rolled back to v3 → still no env vars → repeat.

**Fix:** Add `gatus-secret` to `substituteFrom` in `ks.yaml`. Flux now bakes the actual OIDC client ID and secret directly into the ConfigMap at render time. Gatus reads literal values — no runtime env var dependency, no deadlock.

The `optional: true` flag on the substituteFrom entry means the Kustomization won't fail on first deploy before ESO has created the secret.

## Test plan

- [ ] `kubectl get pods -n monitoring gatus-*` reaches `Running`
- [ ] `kubectl get configmap -n monitoring gatus-config -o jsonpath='{.data.config\.yaml}'` shows actual UUID values for client-id/secret (not `${...}`)
- [ ] Navigating to https://gatus.example.com redirects to Authentik login

🤖 Generated with [Claude Code](https://claude.com/claude-code)
