### PR TITLE
fix(grafana): remove trailing slash from OAuth api_url

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -40,8 +40,9 @@ spec:
         scopes: openid email profile
         auth_url: https://auth.thegeekybits.com/application/o/authorize/
         token_url: https://auth.thegeekybits.com/application/o/token/
-        api_url: https://auth.thegeekybits.com/application/o/userinfo/
+        api_url: https://auth.thegeekybits.com/application/o/userinfo
         role_attribute_path: contains(groups[*], 'authentik Admins') && 'Admin' || 'Viewer'
+        role_attribute_strict: false
 
     persistence:
       enabled: true


### PR DESCRIPTION
## Summary

- Removes trailing slash from `grafana.ini auth.generic_oauth.api_url` — Grafana appends `/emails` to this URL when fetching the user's email, causing a double-slash (`/userinfo//emails`) that returns a 404 from Authentik
- Adds `role_attribute_strict: false` so a missing/empty groups claim falls back to Viewer role instead of denying login
- Updates `setup-authentik-oidc` skill to always fetch an RSA signing key before creating providers (prevents the HS256 vs RS256 mismatch) and to use the correct api_url without trailing slash

## Test plan

- [ ] Grafana OIDC flow completes — user lands on Grafana dashboard after Authentik login
- [ ] `kubectl logs -n monitoring -l app.kubernetes.io/name=grafana -c grafana | grep oauth` — no 404 errors on userinfo endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)