### PR TITLE
feat(tools): deploy Forgejo git hosting

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: forgejo-secret
+    template:
+      data:
+        # Admin password (chart expects key "password")
+        password: "{{ .admin_password }}"
+        # PostgreSQL credentials (custom key names via secretKeys)
+        db-password: "{{ .db_password }}"
+        # Forgejo config secrets (injected via additionalConfigSources)
+        FORGEJO__security__SECRET_KEY: "{{ .secret_key }}"
+        FORGEJO__server__LFS_JWT_SECRET: "{{ .lfs_jwt_secret }}"
+  dataFrom:
+    - extract:
+        key: forgejo

--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgejo
+  interval: 1h
+  values:
+    image:
+      rootless: true
+
+    podAnnotations:
+      reloader.stakater.com/auto: "true"
+
+    service:
+      http:
+        type: ClusterIP
+        port: 3000
+      ssh:
+        type: LoadBalancer
+        port: 22
+
+    persistence:
+      enabled: true
+      storageClass: longhorn
+      size: 10Gi
+
+    gitea:
+      admin:
+        existingSecret: forgejo-secret
+
+      additionalConfigSources:
+        - secret:
+            secretName: forgejo-secret
+
+      config:
+        server:
+          DOMAIN: "git.${SECRET_DOMAIN}"
+          ROOT_URL: "https://git.${SECRET_DOMAIN}"
+          SSH_DOMAIN: "git.${SECRET_DOMAIN}"
+          SSH_PORT: 22
+          START_SSH_SERVER: true
+
+        service:
+          DISABLE_REGISTRATION: false
+          REQUIRE_SIGNIN_VIEW: false
+          DEFAULT_KEEP_EMAIL_PRIVATE: true
+
+        repository:
+          DEFAULT_PRIVATE: last
+
+        openid:
+          ENABLE_OPENID_SIGNIN: true
+          ENABLE_OPENID_SIGNUP: true
+
+        # OIDC is configured post-deploy via Forgejo admin UI:
+        # Administration > Identity & Access > Authentication Sources
+        # Provider: OpenID Connect
+        # Discovery URL: https://authentik.${SECRET_DOMAIN}/application/o/forgejo/.well-known/openid-configuration
+
+    # PostgreSQL subchart (Bitnami)
+    postgresql:
+      enabled: true
+      global:
+        postgresql:
+          auth:
+            existingSecret: forgejo-secret
+            secretKeys:
+              adminPasswordKey: db-password
+              userPasswordKey: db-password
+            database: forgejo
+            username: forgejo
+      primary:
+        persistence:
+          enabled: true
+          storageClass: longhorn
+          size: 5Gi
+
+    # Disable Redis cluster (use memory for single-pod)
+    redis-cluster:
+      enabled: false
+
+    # Disable HA PostgreSQL
+    postgresql-ha:
+      enabled: false
+
+    strategy:
+      type: Recreate
+
+    resources:
+      requests:
+        cpu: 200m
+        memory: 512Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/tools/forgejo/app/httproute.yaml
+++ b/kubernetes/apps/tools/forgejo/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forgejo
+spec:
+  hostnames:
+    - "git.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: forgejo-http
+          port: 3000

--- a/kubernetes/apps/tools/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/tools/forgejo/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/tools/forgejo/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/forgejo/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 16.0.2
+  url: oci://code.forgejo.org/forgejo-helm/forgejo

--- a/kubernetes/apps/tools/forgejo/ks.yaml
+++ b/kubernetes/apps/tools/forgejo/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/forgejo/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./kms/ks.yaml
+  - ./forgejo/ks.yaml


### PR DESCRIPTION
## Summary
- Deploys Forgejo (Gitea-compatible) git hosting to the `tools` namespace
- Official OCI Helm chart from `code.forgejo.org`
- Built-in PostgreSQL subchart with Longhorn persistence (10Gi repos, 5Gi DB)
- SSH access via LoadBalancer on port 22
- OIDC configured post-deploy via admin UI (Administration → Identity & Access → Authentication Sources)

## 1Password prereqs
Run `.private/create-phase2-secrets.sh` before merging. Required fields in `forgejo` item:
- `admin_password` — Forgejo admin account password
- `db_password` — PostgreSQL password
- `secret_key` — 64-char hex for cookie/CSRF signing
- `lfs_jwt_secret` — 43-char base64 for LFS JWT signing

## Post-deploy OIDC setup
After Forgejo is running, configure Authentik OIDC via:
1. Run `/setup-authentik-oidc` for app=forgejo, namespace=tools
2. In Forgejo admin: Site Administration → Identity & Access → Authentication Sources → Add OAuth2
   - Provider: OpenID Connect
   - Discovery URL: `https://auth.<domain>/application/o/forgejo/.well-known/openid-configuration`

## Test plan
- [ ] `kubectl get pods -n tools` — forgejo + postgresql pods Running
- [ ] `kubectl get externalsecret forgejo -n tools` — Ready
- [ ] `https://git.<domain>` loads Forgejo UI
- [ ] SSH clone works on port 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)