### PR TITLE
feat(tools): deploy Zipline file sharing

### DIFF
--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./kms/ks.yaml
   - ./forgejo/ks.yaml
+  - ./zipline/ks.yaml

--- a/kubernetes/apps/tools/zipline/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/zipline/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zipline
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: zipline-secret
+    template:
+      data:
+        CORE_SECRET: "{{ .core_secret }}"
+        DATABASE_URL: "postgresql://zipline:{{ .db_password }}@zipline-postgresql:5432/zipline"
+        POSTGRES_PASSWORD: "{{ .db_password }}"
+  dataFrom:
+    - extract:
+        key: zipline

--- a/kubernetes/apps/tools/zipline/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/zipline/app/helmrelease.yaml
@@ -128,3 +128,7 @@ spec:
           - name: envoy-external
             namespace: network
             sectionName: https
+        rules:
+          - backendRefs:
+              - name: zipline
+                port: 3000

--- a/kubernetes/apps/tools/zipline/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/zipline/app/helmrelease.yaml
@@ -1,0 +1,130 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zipline
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: zipline
+  interval: 1h
+  values:
+    controllers:
+      zipline:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "17"
+            env:
+              INIT_POSTGRES_HOST: zipline-postgresql
+              INIT_POSTGRES_SUPER_USER: postgres
+              INIT_POSTGRES_SUPER_PASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: zipline-secret
+                    key: POSTGRES_PASSWORD
+              INIT_POSTGRES_USER: zipline
+              INIT_POSTGRES_PASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: zipline-secret
+                    key: POSTGRES_PASSWORD
+              INIT_POSTGRES_DBNAME: zipline
+        containers:
+          app:
+            image:
+              repository: ghcr.io/diced/zipline
+              tag: v4
+            env:
+              TZ: America/New_York
+            envFrom:
+              - secretRef:
+                  name: zipline-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 512Mi
+
+      postgresql:
+        type: Deployment
+        containers:
+          postgres:
+            image:
+              repository: postgres
+              tag: "17-alpine"
+            env:
+              POSTGRES_USER: postgres
+              POSTGRES_DB: zipline
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: zipline-secret
+                    key: POSTGRES_PASSWORD
+              PGDATA: /var/lib/postgresql/data/pgdata
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 256Mi
+        pod:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+
+    service:
+      app:
+        controller: zipline
+        ports:
+          http:
+            port: *port
+      postgresql:
+        controller: postgresql
+        ports:
+          postgres:
+            port: 5432
+
+    persistence:
+      uploads:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        advancedMounts:
+          zipline:
+            app:
+              - path: /zipline/uploads
+      db-data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        advancedMounts:
+          postgresql:
+            postgres:
+              - path: /var/lib/postgresql/data
+
+    route:
+      app:
+        hostnames: ["zipline.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/tools/zipline/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/zipline/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
                 memory: 512Mi
 
       postgresql:
-        type: Deployment
+        type: deployment
         containers:
           postgres:
             image:

--- a/kubernetes/apps/tools/zipline/app/kustomization.yaml
+++ b/kubernetes/apps/tools/zipline/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/tools/zipline/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/zipline/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zipline
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/zipline/ks.yaml
+++ b/kubernetes/apps/tools/zipline/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: zipline
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/zipline/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false


### PR DESCRIPTION
## Summary
- Deploys Zipline v4 file sharing/upload service to the `tools` namespace
- bjw-s app-template with sidecar PostgreSQL 17 (Longhorn persistence)
- postgres-init container handles DB bootstrapping
- Public access via `envoy-external` (Cloudflare Tunnel)
- OIDC configured post-deploy via Zipline web dashboard

## 1Password prereqs
Run `.private/create-phase2-secrets.sh` before merging. Required fields in `zipline` item:
- `core_secret` — cookie signing secret
- `db_password` — PostgreSQL password (also used to construct DATABASE_URL in ExternalSecret)

## Post-deploy OIDC setup
After Zipline is running, configure OIDC via the dashboard:
Dashboard → User Settings → OAuth → Enable → enter Authentik provider details
Run `/setup-authentik-oidc` first to create the provider and get the client ID/secret.

## Note on kustomization.yaml conflict
This PR and the Forgejo PR (#117) both modify `kubernetes/apps/tools/kustomization.yaml`.
Merge Forgejo first, then this PR will need its kustomization.yaml updated to include both entries.

## Test plan
- [ ] `kubectl get pods -n tools` — zipline + postgresql pods Running
- [ ] `kubectl get externalsecret zipline -n tools` — Ready
- [ ] `https://zipline.<domain>` loads Zipline UI
- [ ] File upload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)