### PR TITLE
fix(forgejo): split secret to fix init-app-ini crash

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -1,4 +1,5 @@
 ---
+# Admin credentials and database password for Forgejo
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -14,9 +15,27 @@ spec:
       data:
         # Admin password (chart expects key "password")
         password: "{{ .admin_password }}"
-        # PostgreSQL credentials (custom key names via secretKeys)
+        # PostgreSQL credentials
         db-password: "{{ .db_password }}"
-        # Forgejo config secrets (injected via additionalConfigSources)
+  dataFrom:
+    - extract:
+        key: forgejo
+---
+# Forgejo app.ini config secrets (injected via additionalConfigSources)
+# Must only contain FORGEJO__section__key formatted entries
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-config
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: forgejo-config-secret
+    template:
+      data:
         FORGEJO__security__SECRET_KEY: "{{ .secret_key }}"
         FORGEJO__server__LFS_JWT_SECRET: "{{ .lfs_jwt_secret }}"
   dataFrom:

--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
 
       additionalConfigSources:
         - secret:
-            secretName: forgejo-secret
+            secretName: forgejo-config-secret
 
       config:
         server:


### PR DESCRIPTION
## Summary

- Splits `forgejo-secret` into two ExternalSecrets to fix the `init-app-ini` init container crash
- Root cause: `additionalConfigSources` injects **all** secret keys as `app.ini` INI settings; the `password` and `db-password` keys don't follow `FORGEJO__section__key` format → `! invalid setting` error
- **`forgejo-secret`** now contains only `password` + `db-password` (for admin auth & PostgreSQL)
- **`forgejo-config-secret`** contains only `FORGEJO__security__SECRET_KEY` and `FORGEJO__server__LFS_JWT_SECRET` (valid INI config entries)
- `additionalConfigSources` updated to reference `forgejo-config-secret`

## Test plan

- [ ] CI passes (flux-local validation)
- [ ] After Flux reconciles: `forgejo-config` ExternalSecret syncs (`kubectl get es -n tools`)
- [ ] `forgejo-config-secret` Kubernetes Secret is created
- [ ] Forgejo pod starts successfully (init-app-ini no longer crashes)
- [ ] Forgejo accessible at `https://git.${SECRET_DOMAIN}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)