### PR TITLE
fix(forgejo): correct additionalConfigSources secret key format

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -22,7 +22,8 @@ spec:
         key: forgejo
 ---
 # Forgejo app.ini config secrets (injected via additionalConfigSources)
-# Must only contain FORGEJO__section__key formatted entries
+# Keys must be section names; values are INI key=value pairs (newline-separated)
+# This matches the format used by forgejo-inline-config (created by the chart)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -36,8 +37,10 @@ spec:
     name: forgejo-config-secret
     template:
       data:
-        FORGEJO__security__SECRET_KEY: "{{ .secret_key }}"
-        FORGEJO__server__LFS_JWT_SECRET: "{{ .lfs_jwt_secret }}"
+        # [security] section
+        security: "SECRET_KEY={{ .secret_key }}"
+        # [server] section
+        server: "LFS_JWT_SECRET={{ .lfs_jwt_secret }}"
   dataFrom:
     - extract:
         key: forgejo


### PR DESCRIPTION
## Summary

- Fixes the remaining `init-app-ini` crash: `! invalid setting` on the `forgejo-config-secret` keys
- Root cause: `additionalConfigSources` secrets must use **section names** as keys with `KEY=VALUE` pairs as values — not `FORGEJO__section__key` env var format
- Discovered by inspecting `forgejo-inline-config` (the chart's own internal config secret), which uses `security: "INSTALL_LOCK=true"`, `server: "DOMAIN=...\nROOT_URL=..."`, etc.

**Before (wrong — `FORGEJO__` env var format):**
```yaml
FORGEJO__security__SECRET_KEY: "{{ .secret_key }}"
FORGEJO__server__LFS_JWT_SECRET: "{{ .lfs_jwt_secret }}"
```

**After (correct — section-name keys with INI pairs):**
```yaml
security: "SECRET_KEY={{ .secret_key }}"
server: "LFS_JWT_SECRET={{ .lfs_jwt_secret }}"
```

## Test plan

- [ ] CI passes
- [ ] After merge + Flux reconcile: `forgejo-config-secret` has keys `security` and `server`
- [ ] `init-app-ini` init container completes successfully
- [ ] Forgejo pod starts and is accessible at `https://git.${SECRET_DOMAIN}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)