### PR TITLE
fix(forgejo): add admin username key to forgejo-secret

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -13,6 +13,8 @@ spec:
     name: forgejo-secret
     template:
       data:
+        # Admin username (chart expects key "username")
+        username: "{{ .admin_username }}"
         # Admin password (chart expects key "password")
         password: "{{ .admin_password }}"
         # PostgreSQL credentials


### PR DESCRIPTION
## Summary

- `configure-gitea` init container requires a `username` key in the admin `existingSecret`
- Added `admin_username` field to the `forgejo` 1Password item (value: `forgejo_admin`)
- ExternalSecret now maps `admin_username` → `username` in `forgejo-secret`

## Test plan

- [ ] CI passes
- [ ] After Flux reconcile: `forgejo-secret` has `username`, `password`, `db-password` keys
- [ ] `configure-gitea` init container succeeds
- [ ] Forgejo pod becomes Ready
- [ ] Forgejo accessible at `https://git.${SECRET_DOMAIN}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)