### PR TITLE
feat(media): deploy SABnzbd Usenet download client

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./metube/ks.yaml
+  - ./sabnzbd/ks.yaml

--- a/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sabnzbd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: sabnzbd-secret
+    template:
+      data:
+        SABNZBD__API_KEY: "{{ .api_key }}"
+        SABNZBD__NZB_KEY: "{{ .nzb_key }}"
+  dataFrom:
+    - extract:
+        key: sabnzbd

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sabnzbd
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: sabnzbd
+  interval: 1h
+  values:
+    controllers:
+      sabnzbd:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/sabnzbd
+              tag: 4.5.1
+            env:
+              TZ: America/New_York
+              SABNZBD__HOST_WHITELIST_ENTRIES: >-
+                sabnzbd,
+                sabnzbd.media,
+                sabnzbd.media.svc,
+                sabnzbd.media.svc.cluster,
+                sabnzbd.media.svc.cluster.local,
+                sabnzbd.${SECRET_DOMAIN}
+            envFrom:
+              - secretRef:
+                  name: sabnzbd-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api?mode=version
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+    service:
+      app:
+        controller: sabnzbd
+        ports:
+          http:
+            port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        globalMounts:
+          - path: /config
+      # NFS media mount - single root for hardlink support
+      media:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: /volume1/media
+        globalMounts:
+          - path: /data/media
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/sabnzbd/app/ocirepository.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sabnzbd
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sabnzbd
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/sabnzbd/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false


### PR DESCRIPTION
## Summary

- Deploys SABnzbd to the `media` namespace using `ghcr.io/home-operations/sabnzbd`
- 1Gi Longhorn PVC for config; NFS media mount at `/data/media` (single root for hardlink support)
- Whitelist entries pre-configured for cluster-internal service DNS names
- Internal HTTPS route via `envoy-internal` gateway
- API key and NZB key synced from 1Password `sabnzbd` item via ExternalSecret

## Pre-merge checklist

- [ ] Create `sabnzbd` item in 1Password `homeops` vault with `api_key` and `nzb_key` fields
- [ ] Confirm `NFS_SERVER` cluster secret points to correct NAS IP/hostname
- [ ] After first boot: configure Usenet server(s) in SABnzbd settings

## Test plan

- [ ] Flux reconciles HelmRelease and ExternalSecret successfully
- [ ] Pod reaches Running state
- [ ] SABnzbd web UI accessible at `https://sabnzbd.${SECRET_DOMAIN}` (Authentik forward-auth)
- [ ] API key pre-populated from secret (check Settings → General)

🤖 Generated with [Claude Code](https://claude.com/claude-code)