### PR TITLE
feat(media): add Plex Media Server deployment

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -9,4 +9,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./metube/ks.yaml
+  - ./plex/ks.yaml
   - ./sabnzbd/ks.yaml

--- a/kubernetes/apps/media/plex/app/externalsecret.yaml
+++ b/kubernetes/apps/media/plex/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plex
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: plex-secret
+    template:
+      data:
+        PLEX_CLAIM: "{{ .plex_claim }}"
+  dataFrom:
+    - extract:
+        key: plex

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plex
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: plex
+  interval: 1h
+  values:
+    controllers:
+      plex:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/home-operations/plex
+              tag: 1.41.7.4578-cc232efe7
+            env:
+              TZ: America/New_York
+              PLEX_ADVERTISE_URL: "https://plex.${SECRET_DOMAIN}:443"
+              PLEX_NO_AUTH_NETWORKS: "10.0.0.0/8"
+            envFrom:
+              - secretRef:
+                  name: plex-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /identity
+                    port: &port 32400
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 500m
+              limits:
+                memory: 4Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+    service:
+      app:
+        controller: plex
+        type: LoadBalancer
+        ports:
+          http:
+            port: *port
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        globalMounts:
+          - path: /config
+      transcode:
+        type: emptyDir
+        globalMounts:
+          - path: /transcode
+      media:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: /volume1/media
+        globalMounts:
+          - path: /media
+            readOnly: true
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/media/plex/app/ocirepository.yaml
+++ b/kubernetes/apps/media/plex/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plex
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: plex
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/plex/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false


### PR DESCRIPTION
## Summary
- Deploy Plex Media Server using bjw-s app-template
- Single NFS mount at `/media` for all media content (no individual folder mappings)
- Longhorn PVC for config (10Gi), emptyDir for transcode
- ExternalSecret for Plex claim token from 1Password
- LoadBalancer service + Envoy internal route

## Test plan
- [ ] Verify ExternalSecret syncs from 1Password
- [ ] Confirm NFS `/media` mount is accessible in pod
- [ ] Validate Plex UI loads at `plex.${SECRET_DOMAIN}`
- [ ] Check media libraries can be added from `/media` subdirectories

🤖 Generated with [Claude Code](https://claude.com/claude-code)