### PR TITLE
feat(grimmory): deploy Grimmory ebook manager

### DIFF
--- a/.taskfiles/validate/scripts/validate-secret-keys.sh
+++ b/.taskfiles/validate/scripts/validate-secret-keys.sh
@@ -35,7 +35,7 @@ while IFS= read -r -d '' file; do
     [[ -z "$target_name" || "$target_name" == "null" ]] && continue
 
     # Extract all keys from template.data
-    keys=$(yq eval-all "select(.kind == \"ExternalSecret\") | select(document_index == $i) | .spec.target.template.data | keys | .[]" "$file" 2>/dev/null | tr '\n' ',' | sed 's/,$//')
+    keys=$(yq eval-all "select(.kind == \"ExternalSecret\") | select(document_index == $i) | .spec.target.template.data | keys | .[]" "$file" 2>/dev/null | tr '\n' ',' | sed 's/,$//' || true)
     [[ -z "$keys" ]] && continue
 
     map_key="${app_dir}::${target_name}"

--- a/.taskfiles/validate/scripts/validate-secrets.sh
+++ b/.taskfiles/validate/scripts/validate-secrets.sh
@@ -41,8 +41,8 @@ while IFS= read -r -d '' file; do
       continue
     fi
 
-    # Extract field references: {{ .field_name }} patterns
-    referenced_fields=$(echo "$template_data" | grep -oP '\{\{\s*\.\K[a-zA-Z0-9_]+' | sort -u)
+    # Extract field references: {{ .field_name }} patterns in a way that works on macOS/BSD tools too.
+    referenced_fields=$(echo "$template_data" | perl -nle 'while(/\{\{\s*\.([a-zA-Z0-9_]+)/g){print $1}' | sort -u)
     if [[ -z "$referenced_fields" ]]; then
       echo -e "${YELLOW}⚠${NC}  ${es_name}: no {{ .field }} references found in template.data — skipping"
       ((WARNINGS++)) || true

--- a/kubernetes/apps/media/grimmory/app/externalsecret.yaml
+++ b/kubernetes/apps/media/grimmory/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grimmory
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: grimmory-secret
+    template:
+      data:
+        DB_PASSWORD: "{{ .db_password }}"
+        DB_ROOT_PASSWORD: "{{ .db_root_password }}"
+  dataFrom:
+    - extract:
+        key: grimmory

--- a/kubernetes/apps/media/grimmory/app/helmrelease.yaml
+++ b/kubernetes/apps/media/grimmory/app/helmrelease.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grimmory
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: grimmory
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1027
+            runAsGroup: 100
+            fsGroup: 100
+        containers:
+          app:
+            image:
+              repository: grimmory/grimmory
+              tag: v2.3.0
+            env:
+              TZ: America/New_York
+              USER_ID: "1027"
+              GROUP_ID: "100"
+              DATABASE_URL: "jdbc:mariadb://grimmory-mariadb:3306/grimmory"
+              DATABASE_USERNAME: grimmory
+              DATABASE_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: grimmory-secret
+                    key: DB_PASSWORD
+              DISK_TYPE: NETWORK
+              SWAGGER_ENABLED: "false"
+              FORCE_DISABLE_OIDC: "true"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/healthcheck
+                    port: &port 6060
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+
+      mariadb:
+        pod:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+        containers:
+          mariadb:
+            image:
+              repository: mariadb
+              tag: "11"
+            env:
+              MYSQL_ROOT_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: grimmory-secret
+                    key: DB_ROOT_PASSWORD
+              MYSQL_DATABASE: grimmory
+              MYSQL_USER: grimmory
+              MYSQL_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: grimmory-secret
+                    key: DB_PASSWORD
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+      mariadb:
+        controller: mariadb
+        ports:
+          mysql:
+            port: 3306
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        advancedMounts:
+          main:
+            app:
+              - path: /app/data
+      db-data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        advancedMounts:
+          mariadb:
+            mariadb:
+              - path: /var/lib/mysql
+      bookdrop:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        advancedMounts:
+          main:
+            app:
+              - path: /bookdrop
+      books:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: /volume1/media
+        advancedMounts:
+          main:
+            app:
+              - path: /books
+
+    route:
+      app:
+        hostnames: ["books.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: grimmory-main
+                port: 6060

--- a/kubernetes/apps/media/grimmory/app/kustomization.yaml
+++ b/kubernetes/apps/media/grimmory/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/media/grimmory/app/ocirepository.yaml
+++ b/kubernetes/apps/media/grimmory/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grimmory
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/grimmory/ks.yaml
+++ b/kubernetes/apps/media/grimmory/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grimmory
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/grimmory/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./recyclarr/ks.yaml
   - ./bazarr/ks.yaml
   - ./unpackerr/ks.yaml
+  - ./grimmory/ks.yaml
   # - ./booklore/ks.yaml ## FUP: BookLore image gone (org deleted); evaluate Grimmory (grimmory/grimmory) as successor
   - ./audiobookshelf/ks.yaml
   # - ./plex/ks.yaml ## Disabling temporarily


### PR DESCRIPTION
## Summary
- deploy Grimmory in the media namespace as the internal-only BookLore successor
- add ExternalSecret and MariaDB-backed bjw-s app-template manifests for the new service
- make local validation scripts portable on this macOS workspace so preflight checks can run here

## Validation
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" task validate:secret-keys
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" task validate:routes
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" task validate:substitutions
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" flux-local test --enable-helm --all-namespaces --path "/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/kubernetes/flux/cluster" -v 2>&1 | grep -E 'grimmory(::| )'
- Grimmory Docker Hub tag check via https://hub.docker.com/v2/repositories/grimmory/grimmory/tags/v2.3.0

## Notes
- repo-wide validate:preflight and validate:images still report unrelated pre-existing failures outside Grimmory scope
