### PR TITLE
fix(grimmory): allow root entrypoint bootstrap

### DIFF
--- a/kubernetes/apps/media/grimmory/app/helmrelease.yaml
+++ b/kubernetes/apps/media/grimmory/app/helmrelease.yaml
@@ -13,12 +13,6 @@ spec:
       main:
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1027
-            runAsGroup: 100
-            fsGroup: 100
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary
- allow the Grimmory container to start as root so its upstream entrypoint can create the target media user and drop privileges correctly
- keep the app process UID/GID aligned to the media user via USER_ID/GROUP_ID envs

## Validation
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" flux-local test --enable-helm --all-namespaces --path "/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/kubernetes/flux/cluster" -v 2>&1 | grep -E 'grimmory(::| )'
- observed previous pod failure: 
