### PR TITLE
fix(grimmory): allow entrypoint privilege drop

### DIFF
--- a/kubernetes/apps/media/grimmory/app/helmrelease.yaml
+++ b/kubernetes/apps/media/grimmory/app/helmrelease.yaml
@@ -45,10 +45,6 @@ spec:
                   timeoutSeconds: 5
                   failureThreshold: 3
               readiness: *probes
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Summary
- remove the remaining container-level hardening that blocked Grimmory's root entrypoint from creating the runtime user and dropping privileges
- keep this deployment focused on getting the upstream image booting reliably before any follow-up hardening pass

## Validation
- PATH="/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/.venv/bin:/Users/shawnmix/Library/Application Support/carapace/bin:/Users/shawnmix/.opencode/bin:/Users/shawnmix/go/bin:/opt/homebrew/opt/go/libexec/bin:/Users/shawnmix/.bun/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Applications/Ghostty.app/Contents/MacOS:/Users/shawnmix/.lmstudio/bin:/Users/shawnmix/.local/bin:/Applications/Obsidian.app/Contents/MacOS" flux-local test --enable-helm --all-namespaces --path "/Users/shawnmix/Library/Mobile Documents/com~apple~CloudDocs/Documents/1 Projects/home-ops/.worktrees/claude-deploy-grimmory-prd12/kubernetes/flux/cluster" -v > /tmp/grimmory-flux.txt && grep grimmory /tmp/grimmory-flux.txt
- live pod logs before fix: adduser /home/booklore operation not permitted; su-exec setgroups operation not permitted
