### PR TITLE
fix: hardcode bjw-s security context IDs

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -50,9 +50,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: plex

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -53,9 +53,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: radarr

--- a/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
@@ -53,9 +53,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: radarr4k

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -55,9 +55,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: sabnzbd

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -53,9 +53,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: sonarr

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -43,9 +43,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     persistence:
       media:
         type: nfs

--- a/kubernetes/apps/tools/rackpeek/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/rackpeek/app/helmrelease.yaml
@@ -47,9 +47,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
 
     service:
       main:

--- a/kubernetes/apps/tools/syncthing/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/syncthing/app/helmrelease.yaml
@@ -49,9 +49,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: ${MEDIA_UID}
-        runAsGroup: ${MEDIA_GID}
-        fsGroup: ${MEDIA_GID}
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
 
     service:
       app:


### PR DESCRIPTION
## Summary
- replace `${MEDIA_UID}` and `${MEDIA_GID}` substitutions in bjw-s securityContext blocks with fixed numeric IDs
- set `runAsUser` to `1027` and both `runAsGroup` and `fsGroup` to `100` across the affected media and tools manifests
- leave unrelated `PUID` and `PGID` environment variable substitutions unchanged

## Validation
- `task validate:preflight` *(fails due to pre-existing missing 1Password items for atuin, forgejo, zipline, authentik, and qbittorrent; not caused by this change)*
- `task validate:flux` *(fails in the local environment because `.venv/bin/flux-local` points at a missing Python interpreter path)*