### PR TITLE
feat(hermes-agent): deploy Nous Research Hermes Agent

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: hermes-agent-secret
+  dataFrom:
+    - extract:
+        key: hermes-agent

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes-agent
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hermes-agent
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsUser: 10000
+            runAsGroup: 10000
+            fsGroup: 10000
+        containers:
+          gateway:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.16
+            # Bootstrap: sleep until `hermes setup` is run via kubectl exec.
+            # After setup, change command to: ["hermes", "gateway", "run"]
+            command: ["/bin/sleep", "infinity"]
+            env:
+              HERMES_HOME: /opt/data
+              PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
+              PYTHONUNBUFFERED: "1"
+              TELEGRAM_BOT_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes-agent-secret
+                    key: TELEGRAM_BOT_TOKEN
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 3Gi
+          dashboard:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.16
+            # Bootstrap: sleep until `hermes setup` is run via kubectl exec.
+            # After setup, change command to: ["hermes", "dashboard", "--host", "0.0.0.0", "--no-open"]
+            # Also add HTTP liveness/readiness probes: httpGet path: / port: 9119
+            command: ["/bin/sleep", "infinity"]
+            env:
+              HERMES_HOME: /opt/data
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 9119
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        globalMounts:
+          - path: /opt/data
+      shared:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/hermes"
+        globalMounts:
+          - path: /opt/data/shared
+
+    route:
+      app:
+        hostnames: ["hermes.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: hermes-agent-main
+                port: 9119

--- a/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/hermes-agent/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes-agent
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes-agent/ks.yaml
+++ b/kubernetes/apps/ai/hermes-agent/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-agent
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes-agent/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ./n8n/ks.yaml
   - ./librechat/ks.yaml
   - ./pai/ks.yaml
+  - ./hermes-agent/ks.yaml


### PR DESCRIPTION
## Summary

- Adds [Hermes Agent](https://github.com/NousResearch/hermes-agent) (Nous Research) to the `ai` namespace
- Two-container pod (gateway + dashboard) sharing a 20Gi Longhorn PVC at `/opt/data`
- Syncthing NFS share mounted at `/opt/data/shared` → `/volume1/syncthing/ic_documents/5 Shared/hermes` for artifact access across devices
- Internal HTTPRoute at `hermes.${SECRET_DOMAIN}` via `envoy-internal`
- Telegram bot token provisioned via 1Password ExternalSecret (`hermes-agent` item, `homeops` vault)
- Pinned to `v2026.5.16` — Renovate will open PRs for future releases

## Bootstrap steps (after merge + Flux reconcile)

1. **Pre-deploy prereq:** Create the NFS folder on Synology if it doesn't exist:
   ```
   mkdir -p "/volume1/syncthing/ic_documents/5 Shared/hermes"
   ```
2. Confirm pod is up and volumes mounted:
   ```
   kubectl -n ai get hr,pod,pvc -l app.kubernetes.io/name=hermes-agent
   kubectl -n ai exec deploy/hermes-agent -c gateway -- ls /opt/data /opt/data/shared
   ```
3. Run the one-time interactive setup wizard:
   ```
   kubectl -n ai exec -it deploy/hermes-agent -c gateway -- hermes setup
   ```
4. After setup completes, edit `helmrelease.yaml` to switch both container commands:
   - `gateway`: `["hermes", "gateway", "run"]`
   - `dashboard`: `["hermes", "dashboard", "--host", "0.0.0.0", "--no-open"]`
   - Add HTTP liveness/readiness probes on dashboard (`/` → port 9119)
5. Commit → Flux applies → `https://hermes.${SECRET_DOMAIN}` is live

## Test plan

- [ ] Flux HelmRelease reaches `Ready` state
- [ ] Pod comes up with both containers running (`sleep infinity`)
- [ ] PVC bound (20Gi, Longhorn)
- [ ] NFS mount accessible at `/opt/data/shared`
- [ ] ExternalSecret syncs `hermes-agent-secret` with `TELEGRAM_BOT_TOKEN`
- [ ] HTTPRoute resolves on internal LAN
- [ ] `hermes setup` completes and writes `/opt/data/config.yaml`, `.env`, `SOUL.md`
- [ ] After step 4 commit: dashboard loads at `https://hermes.${SECRET_DOMAIN}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)