### PR TITLE
fix(hermes-agent): use args instead of command for bootstrap sleep

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -23,9 +23,10 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # Bootstrap: sleep until `hermes setup` is run via kubectl exec.
-            # After setup, change command to: ["hermes", "gateway", "run"]
-            command: ["/bin/sleep", "infinity"]
+            # Bootstrap: entrypoint detects `sleep` as an executable and passes through,
+            # activating the venv and scaffolding /opt/data before sleeping.
+            # After `hermes setup`, change args to: ["gateway", "run"]
+            args: ["sleep", "infinity"]
             env:
               HERMES_HOME: /opt/data
               PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
@@ -45,10 +46,10 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # Bootstrap: sleep until `hermes setup` is run via kubectl exec.
-            # After setup, change command to: ["hermes", "dashboard", "--host", "0.0.0.0", "--no-open"]
+            # Bootstrap: same pattern — entrypoint runs, venv activated, then sleeps.
+            # After setup, change args to: ["dashboard", "--host", "0.0.0.0", "--no-open"]
             # Also add HTTP liveness/readiness probes: httpGet path: / port: 9119
-            command: ["/bin/sleep", "infinity"]
+            args: ["sleep", "infinity"]
             env:
               HERMES_HOME: /opt/data
             resources:


### PR DESCRIPTION
## Summary

Follow-up fix to #246. The initial deploy used `command: ["/bin/sleep", "infinity"]` which overrides the container's ENTRYPOINT (`tini → entrypoint.sh`) entirely. This meant the venv at `/opt/hermes/.venv` never got activated and `hermes` was not on PATH, causing:

```
error: exec: "hermes": executable file not found in $PATH
```

Switches to `args: ["sleep", "infinity"]` so `entrypoint.sh` still runs first (activates venv, scaffolds `/opt/data`), then detects `sleep` as an executable and passes through. After Flux reconciles, exec in with:

```bash
kubectl -n ai exec -it deploy/hermes-agent -c gateway -- \
  bash -c "source /opt/hermes/.venv/bin/activate && hermes setup"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)