### PR TITLE
feat(hermes-agent): go live — real commands + --insecure dashboard bind

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -23,10 +23,7 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # Bootstrap: entrypoint detects `sleep` as an executable and passes through,
-            # activating the venv and scaffolding /opt/data before sleeping.
-            # After `hermes setup`, change args to: ["gateway", "run"]
-            args: ["sleep", "infinity"]
+            args: ["gateway", "run"]
             env:
               HERMES_HOME: /opt/data
               PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
@@ -46,12 +43,22 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # Bootstrap: same pattern — entrypoint runs, venv activated, then sleeps.
-            # After setup, change args to: ["dashboard", "--host", "0.0.0.0", "--no-open"]
-            # Also add HTTP liveness/readiness probes: httpGet path: / port: 9119
-            args: ["sleep", "infinity"]
+            args: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
             env:
               HERMES_HOME: /opt/data
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 9119
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness: *probes
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary

Setup wizard complete. Replaces all bootstrap `sleep infinity` with real commands and fixes the dashboard crashloop.

- `gateway`: `args: ["gateway", "run"]`
- `dashboard`: `args: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]`
  - `--insecure` required — Hermes refuses to bind to `0.0.0.0` without it as a guard against public exposure. Safe here: internal LAN only via `envoy-internal`.
- HTTP liveness/readiness probes on dashboard (`GET / :9119`, 30s interval)
- Strips all bootstrap comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)