### PR TITLE
fix(hermes-agent): restore --insecure flag on dashboard

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -43,7 +43,7 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            args: ["dashboard", "--host", "0.0.0.0", "--no-open"]
+            args: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
             env:
               HERMES_HOME: /opt/data
             probes:
@@ -53,7 +53,7 @@ spec:
                 spec:
                   httpGet:
                     path: /
-                    port: &dashport 9119
+                    port: 9119
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 10


### PR DESCRIPTION
## Summary

`--insecure` was dropped during the branch chaos. Without it, Hermes refuses to bind to `0.0.0.0` and the dashboard crashes immediately, causing Flux to exhaust retries and stall.

Also removes an unused `&dashport` YAML anchor.

## After merging

Flux is currently **Stalled** (exhausted retries from the previous failed rollout). After merge, force it to pick up the fix:

\`\`\`bash
flux reconcile helmrelease hermes-agent -n ai --force
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)