### PR TITLE
fix(hermes-agent): correct HTTPRoute backendRef service name

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -53,7 +53,7 @@ spec:
                 spec:
                   httpGet:
                     path: /
-                    port: &dashport 9119
+                    port: 9119
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 10
@@ -97,5 +97,5 @@ spec:
             sectionName: https
         rules:
           - backendRefs:
-              - name: hermes-agent-main
+              - name: hermes-agent
                 port: 9119


### PR DESCRIPTION
## Problem

Dashboard unreachable — blank page. HTTPRoute was pointing backendRef to `hermes-agent-main` but the actual service is `hermes-agent`.

bjw-s app-template naming rule: single `service:` block named `main` → service is `{release-name}` (no suffix). Only multi-service releases get the `{release-name}-{service-name}` form.

## Changes

- `backendRefs.name`: `hermes-agent-main` → `hermes-agent`
- Removes orphaned `&dashport` YAML anchor

## For the Telegram polling conflict

The gateway logs show "Telegram polling conflict — terminated by other getUpdates request." This means another Hermes instance is polling the same bot token — most likely a local Hermes session left running from when you did `hermes setup`. Kill any local `hermes` processes and the conflict will clear within ~30 seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)