### PR TITLE
feat(ai): connect Hermes API server to Open WebUI

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-api.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-api.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-api-server
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: hermes-api-server-secret
+  dataFrom:
+    - extract:
+        key: hermes-api-server

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -28,11 +28,19 @@ spec:
               HERMES_HOME: /opt/data
               PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
               PYTHONUNBUFFERED: "1"
+              API_SERVER_ENABLED: "true"
+              API_SERVER_HOST: "0.0.0.0"
+              API_SERVER_PORT: "8642"
               TELEGRAM_BOT_TOKEN:
                 valueFrom:
                   secretKeyRef:
                     name: hermes-agent-secret
                     key: TELEGRAM_BOT_TOKEN
+              API_SERVER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes-api-server-secret
+                    key: API_SERVER_KEY
             resources:
               requests:
                 cpu: 250m
@@ -72,6 +80,8 @@ spec:
         ports:
           http:
             port: 9119
+          api:
+            port: 8642
 
     persistence:
       data:

--- a/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
+  - ./externalsecret-api.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui-hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: open-webui-hermes-secret
+  data:
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: hermes-api-server
+        property: API_SERVER_KEY

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -20,6 +20,12 @@ spec:
               OLLAMA_BASE_URL: "http://ollama.ai.svc.cluster.local:11434"
               WEBUI_AUTH: "true"
               ENABLE_SIGNUP: "false"
+              OPENAI_API_BASE_URL: "http://hermes-agent.ai.svc.cluster.local:8642/v1"
+              OPENAI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: open-webui-hermes-secret
+                    key: OPENAI_API_KEY
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

- Enables Hermes gateway's built-in OpenAI-compatible API server on port 8642 (`API_SERVER_ENABLED=true`, bound to `0.0.0.0`)
- API key sourced from new `hermes-api-server` 1Password item via a new ExternalSecret
- Exposes port 8642 on the `hermes-agent` service so Open WebUI can reach it in-cluster
- Configures Open WebUI with `OPENAI_API_BASE_URL=http://hermes-agent.ai.svc.cluster.local:8642/v1` and the matching API key

## Test plan

- [ ] Flux reconciles both `hermes-agent` and `open-webui` HelmReleases cleanly
- [ ] `hermes-api-server-secret` and `open-webui-hermes-secret` ExternalSecrets sync from 1Password
- [ ] `curl http://hermes-agent.ai.svc.cluster.local:8642/health` returns 200 after rollout
- [ ] Open WebUI shows Hermes models in the model selector alongside Ollama models
- [ ] Chat via a Hermes model in Open WebUI succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)