### PR TITLE
fix(k8s): pre-flight SA token mount for bjw-s app-template v5 upgrade

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -47,6 +47,8 @@ spec:
                 memory: 512Mi
         serviceAccount:
           name: headlamp
+        pod:
+          automountServiceAccountToken: true
 
     service:
       main:

--- a/kubernetes/apps/tools/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/homepage/app/helmrelease.yaml
@@ -15,6 +15,8 @@ spec:
           reloader.stakater.com/auto: "true"
         serviceAccount:
           name: homepage
+        pod:
+          automountServiceAccountToken: true
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary

- Adds `pod.automountServiceAccountToken: true` to `homepage` and `headlamp` HelmReleases
- Both workloads call the Kubernetes API in-cluster (`homepage` via ClusterRole, `headlamp` via `-in-cluster` flag)
- bjw-s common library v5 (PR #231) changes the default to `false` — this pre-flight change is a no-op on the current v4.6.2 chart and ensures tokens stay mounted when the chart bumps

## Why before PR 231

The value `automountServiceAccountToken: true` is valid in both v4 and v5, making it a safe forward-compatible addition. Landing this first means PR 231 can be merged as-is without touching any values files.

## Test plan

- [ ] Flux reconciles both `homepage` and `headlamp` HelmReleases to `Ready=True`
- [ ] No `401`/`403` errors in homepage or headlamp pod logs
- [ ] Merge PR #231 after this is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)