### PR TITLE
feat(ai): wire Qdrant — route, API key auth, tag pin, mxbai-embed-large

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -14,6 +14,10 @@ data:
         litellm_params:
           model: ollama/phi3:mini
           api_base: http://ollama.ai.svc.cluster.local:11434
+      - model_name: mxbai-embed-large
+        litellm_params:
+          model: ollama/mxbai-embed-large
+          api_base: http://ollama.ai.svc.cluster.local:11434
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
       database_url: os.environ/DATABASE_URL

--- a/kubernetes/apps/ai/qdrant/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/qdrant/app/externalsecret.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qdrant
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: qdrant-secret
+  dataFrom:
+    - extract:
+        key: qdrant

--- a/kubernetes/apps/ai/qdrant/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/qdrant/app/helmrelease.yaml
@@ -11,11 +11,19 @@ spec:
   values:
     controllers:
       main:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
               repository: qdrant/qdrant
-              tag: latest
+              tag: v1.18.0
+            env:
+              QDRANT__SERVICE__API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: qdrant-secret
+                    key: api_key
             probes:
               liveness: &probes
                 enabled: true
@@ -54,3 +62,15 @@ spec:
         size: 5Gi
         globalMounts:
           - path: /qdrant/storage
+
+    route:
+      app:
+        hostnames: ["qdrant.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: qdrant
+                port: 6333

--- a/kubernetes/apps/ai/qdrant/app/kustomization.yaml
+++ b/kubernetes/apps/ai/qdrant/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/ai/qdrant/ks.yaml
+++ b/kubernetes/apps/ai/qdrant/ks.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/ai/qdrant/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary

- **Pin Qdrant image** from `latest` → `v1.18.0` (fixes AGENTS.md rule: never tag latest; Renovate will keep it updated going forward)
- **Add internal HTTPRoute** at `qdrant.example.com` via `envoy-internal` gateway (HTTPS, wildcard cert, internal-only — no external exposure)
- **Add API key auth** via ExternalSecret pulling `api_key` from `homeops/qdrant` in 1Password → `qdrant-secret`; env var `QDRANT__SERVICE__API_KEY` injected into pod
- **Add `postBuild.substituteFrom`** to `ks.yaml` so `${SECRET_DOMAIN}` resolves in the route hostname
- **Add `mxbai-embed-large`** to LiteLLM model list — 1024-dim embedding model proxied to Ollama for agentOS vault indexing

## Context

Qdrant has been running for 52 days as a completely unwired ClusterIP service with no route, no auth, and a `latest` tag. This PR wires it up as the semantic memory backend for agentOS (vault RAG, memory search, Claude Code session search). Local ingestion scripts and launchd schedule are in the vault — this PR is the cluster-side prerequisite.

## Test plan

- [ ] `kubectl -n ai get pod -l app.kubernetes.io/name=qdrant -w` — pod restarts cleanly with new tag
- [ ] `kubectl -n ai get externalsecret qdrant` — status `SecretSynced`
- [ ] `kubectl -n ai get httproute qdrant` — accepted, bound to envoy-internal
- [ ] `curl -H "api-key: <key>" https://qdrant.example.com/collections` — returns `{"result":{"collections":[]}}`
- [ ] `curl https://llm.example.com/v1/models` — includes `mxbai-embed-large` after Ollama pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)
