### PR TITLE
feat(ai): consolidate Hermes credentials into dotenv Secret

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-dotenv
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: hermes-dotenv
+    template:
+      engineVersion: v2
+      data:
+        .env: |
+          TELEGRAM_BOT_TOKEN={{ .TELEGRAM_BOT_TOKEN }}
+          API_SERVER_KEY={{ .API_SERVER_KEY }}
+          HASS_TOKEN={{ .HASS_TOKEN }}
+          HASS_URL={{ .HASS_URL }}
+  dataFrom:
+    - extract:
+        key: hermes-dotenv

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -31,16 +31,6 @@ spec:
               API_SERVER_ENABLED: "true"
               API_SERVER_HOST: "0.0.0.0"
               API_SERVER_PORT: "8642"
-              TELEGRAM_BOT_TOKEN:
-                valueFrom:
-                  secretKeyRef:
-                    name: hermes-agent-secret
-                    key: TELEGRAM_BOT_TOKEN
-              API_SERVER_KEY:
-                valueFrom:
-                  secretKeyRef:
-                    name: hermes-api-server-secret
-                    key: API_SERVER_KEY
             resources:
               requests:
                 cpu: 250m
@@ -97,6 +87,14 @@ spec:
         path: "/volume1/syncthing/ic_documents/5 Shared/hermes"
         globalMounts:
           - path: /opt/data/shared
+
+      hermes-dotenv:
+        type: secret
+        name: hermes-dotenv
+        globalMounts:
+          - path: /opt/data/.env
+            subPath: .env
+            readOnly: true
 
     route:
       app:

--- a/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
@@ -3,6 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
-  - ./externalsecret.yaml
-  - ./externalsecret-api.yaml
+  - ./externalsecret-dotenv.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

- Replaces two single-field ExternalSecrets (`hermes-agent`, `hermes-api-server`) with a single ESO-rendered dotenv Secret mounted at `/opt/data/.env` via `subPath` on the existing Longhorn PVC
- Adds `HASS_TOKEN` and `HASS_URL` for Home Assistant gateway integration (scoped token, separate from `ha-agent-access`)
- All four credentials sourced from new `hermes-dotenv` 1Password item in `homeops` vault

## What changed

| File | Change |
|---|---|
| `externalsecret-dotenv.yaml` | New — renders `hermes-dotenv` 1P item into a `.env`-keyed Secret via ESO template |
| `helmrelease.yaml` | Removed `TELEGRAM_BOT_TOKEN` and `API_SERVER_KEY` secretKeyRef env injections; added `hermes-dotenv` Secret as subPath mount at `/opt/data/.env` (readOnly) |
| `kustomization.yaml` | Swapped old two ExternalSecrets for new single one |

`externalsecret.yaml` and `externalsecret-api.yaml` are still on disk pending post-deploy verification — will be deleted in a follow-up commit once ESO confirms the new Secret is syncing and the pod comes up clean.

## Security notes

- `TELEGRAM_BOT_TOKEN`, `HASS_TOKEN`, and `HASS_URL` are in Hermes's `_HERMES_PROVIDER_ENV_BLOCKLIST` by name and will be automatically stripped from terminal subprocess environments
- `API_SERVER_KEY` is stripped via the messaging/tool category blocklist
- Mount is `readOnly: true`; Stakater Reloader handles pod restarts on Secret rotation (annotation already present)

## Post-merge verification steps

```sh
# 1. ExternalSecret synced
kubectl get externalsecret hermes-dotenv -n ai
kubectl get secret hermes-dotenv -n ai -o jsonpath='{.data.\.env}' | base64 -d | wc -l  # expect 4

# 2. Pod came up and loaded dotenv
kubectl logs -n ai -l app.kubernetes.io/name=hermes-agent -c gateway --tail=100 | grep -i "telegram\|api server"

# 3. Subprocess scrubbing (via Telegram)
# Ask Hermes: "run env | grep -E 'HASS|TELEGRAM|API_SERVER' in the terminal"
# Expected: empty output — all four keys are auto-blocklisted
```

Once verified: delete `externalsecret.yaml` + `externalsecret-api.yaml`, push, archive old `hermes-agent` and `hermes-api-server` 1P items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)