### PR TITLE
fix(ai): correct Hermes dotenv — HA service name and Telegram allowlist

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -15,6 +15,7 @@ spec:
       data:
         .env: |
           TELEGRAM_BOT_TOKEN={{ .TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_ALLOWED_USERS={{ .TELEGRAM_ALLOWED_USERS }}
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           HASS_TOKEN={{ .HASS_TOKEN }}
           HASS_URL={{ .HASS_URL }}


### PR DESCRIPTION
## What

Two issues caught during post-deploy verification of #256:

**1. Wrong HA service name**
`HASS_URL` was set to `home-assistant.home.svc.cluster.local` but the actual service is `home-assistant-app`. Gateway was hitting DNS failures and pausing the HA platform after 10 consecutive failures.

**2. Telegram gateway denying owner messages**
`TELEGRAM_ALLOWED_USERS` was not set, so the gateway's default-deny policy was rejecting all messages including from the bot owner (uid `344049123`). Added to the ESO template.

## Changes

- `externalsecret-dotenv.yaml`: add `TELEGRAM_ALLOWED_USERS` line to the `.env` template

The 1Password `hermes-dotenv` item has already been updated with the corrected `HASS_URL` and new `TELEGRAM_ALLOWED_USERS` field — ESO will re-render the Secret on next sync (or immediately after reconcile), Stakater Reloader will bounce the pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)