### PR TITLE
feat(ai): add internal HTTPRoute for Ollama

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -41,3 +41,15 @@ spec:
         size: 50Gi
         globalMounts:
           - path: /root/.ollama
+
+    route:
+      app:
+        hostnames: ["ollama.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: ollama
+                port: 11434

--- a/kubernetes/apps/ai/ollama/ks.yaml
+++ b/kubernetes/apps/ai/ollama/ks.yaml
@@ -13,3 +13,7 @@ spec:
     namespace: flux-system
   targetNamespace: ai
   wait: false
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret


### PR DESCRIPTION
## Summary

- Adds `route:` block to Ollama HelmRelease exposing `ollama.${SECRET_DOMAIN}` via the `envoy-internal` gateway (same pattern as Qdrant)
- Adds `postBuild.substituteFrom` to `ks.yaml` so `${SECRET_DOMAIN}` resolves from `cluster-secrets`

## Why

Eliminates the `kubectl port-forward` dependency in local tooling (qdrant-sync script). Once this route is live, `OLLAMA_URL` in `~/.config/lifeOS/qdrant-sync.conf` can be updated to `https://ollama.example.com` and the port-forward block removed from `run.sh`.

## Test plan

- [ ] Flux reconciles cleanly — `kubectl -n ai get helmrelease ollama` shows `Ready`
- [ ] HTTPRoute accepted — `kubectl -n ai get httproute ollama`
- [ ] Reachable from Mac: `curl -s https://ollama.example.com/api/tags | jq .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
