### PR TITLE
feat(ai): pull bge-m3 embedding model on Ollama startup

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -18,6 +18,15 @@ spec:
               tag: 0.24.0
             env:
               OLLAMA_HOST: "0.0.0.0"
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |
+                      until ollama list >/dev/null 2>&1; do sleep 2; done
+                      ollama pull bge-m3
             resources:
               requests:
                 cpu: 2000m


### PR DESCRIPTION
## Summary

- Adds a `postStart` lifecycle hook to the Ollama HelmRelease that pulls `bge-m3` after the server is ready
- `bge-m3` has an 8,192-token context window vs the current `mxbai-embed-large`'s 512-token limit — eliminates the truncation issues hitting the agentOS qdrant-sync pipeline
- Same 1024-dim Cosine vectors as mxbai — no Qdrant collection schema changes needed
- Hook is idempotent: `ollama pull` is a no-op if the model is already present on the PVC

## What happens after merge

1. Flux reconciles → Ollama pod restarts → postStart hook runs `ollama pull bge-m3` (~1.2 GB download to the Longhorn PVC)
2. Once model is confirmed available, run a full re-index: `bash run.sh --collection all --full`
3. All existing Qdrant vectors are re-embedded with bge-m3 (mxbai and bge-m3 share 1024-dim space but are not cross-compatible — re-index is required)

## Test plan

- [ ] Flux reconciles HelmRelease without errors
- [ ] `kubectl logs -n ai deploy/ollama` shows `postStart` pulling bge-m3
- [ ] `curl https://ollama.example.com/api/tags` lists `bge-m3`
- [ ] `bash run.sh --collection all --full` completes without embed errors
- [ ] Recall test returns semantically correct hits across all three collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
