### PR TITLE
feat(home): OrcaSlicer web UI + shared NFS print library + Bambuddy upgrade

### DIFF
--- a/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
@@ -17,9 +17,14 @@ spec:
           app:
             image:
               repository: ghcr.io/maziggy/bambuddy
-              tag: 0.2.4
+              tag: v0.2.4.2
             env:
               TZ: America/New_York
+              # VIRTUAL_PRINTER_PASV_ADDRESS: needed for FTP passive mode from OrcaSlicer (in-cluster).
+              # Set to the bambuddy Service ClusterIP:
+              #   kubectl get svc bambuddy -n home -o jsonpath='{.spec.clusterIP}'
+              # Add BAMBUDDY_PASV_ADDRESS to cluster-secrets, then uncomment:
+              # VIRTUAL_PRINTER_PASV_ADDRESS: ${BAMBUDDY_PASV_ADDRESS}
               MFA_ENCRYPTION_KEY:
                 valueFrom:
                   secretKeyRef:
@@ -44,6 +49,10 @@ spec:
                     port: 8000
                   initialDelaySeconds: 15
                   periodSeconds: 10
+            securityContext:
+              capabilities:
+                add:
+                  - NET_BIND_SERVICE
             resources:
               requests:
                 cpu: 50m
@@ -57,6 +66,10 @@ spec:
         ports:
           http:
             port: 8000
+          ftps:
+            port: 990
+          rtsps:
+            port: 322
 
     persistence:
       data:
@@ -66,6 +79,11 @@ spec:
         size: 1Gi
         globalMounts:
           - path: /app/data
+      library:
+        type: persistentVolumeClaim
+        existingClaim: print-library
+        globalMounts:
+          - path: /app/library
 
     route:
       app:

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -8,7 +8,9 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./print-library/ks.yaml
   - ./bambuddy/ks.yaml
+  - ./orcaslicer/ks.yaml
   - ./zwave-js-ui/ks.yaml
   - ./matter-server/ks.yaml
   - ./home-assistant/ks.yaml

--- a/kubernetes/apps/home/orcaslicer/app/externalsecret.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# Requires a 1Password item named "orcaslicer" with fields: username, password
+# These are used to gate the Selkies web-desktop login (CUSTOM_USER / PASSWORD env vars).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: orcaslicer
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: orcaslicer-secret
+    template:
+      data:
+        username: "{{ .username }}"
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: orcaslicer

--- a/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: orcaslicer
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: orcaslicer
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: lscr.io/linuxserver/orcaslicer
+              tag: v2.3.2-ls19
+            env:
+              PUID: "1000"
+              PGID: "1000"
+              TZ: America/New_York
+              CUSTOM_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: orcaslicer-secret
+                    key: username
+              PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: orcaslicer-secret
+                    key: password
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                    scheme: HTTP
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                    scheme: HTTP
+                  initialDelaySeconds: 30
+                  periodSeconds: 15
+                  failureThreshold: 5
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                cpu: "4"
+                memory: 4Gi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 3000
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        globalMounts:
+          - path: /config
+      library:
+        type: persistentVolumeClaim
+        existingClaim: print-library
+        globalMounts:
+          - path: /config/library
+
+    route:
+      app:
+        hostnames: ["orcaslicer.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: orcaslicer
+                port: 3000

--- a/kubernetes/apps/home/orcaslicer/app/kustomization.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/orcaslicer/app/ocirepository.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: orcaslicer
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/orcaslicer/ks.yaml
+++ b/kubernetes/apps/home/orcaslicer/ks.yaml
@@ -2,10 +2,10 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: bambuddy
+  name: orcaslicer
 spec:
   interval: 1h
-  path: ./kubernetes/apps/home/bambuddy/app
+  path: ./kubernetes/apps/home/orcaslicer/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/kubernetes/apps/home/print-library/app/kustomization.yaml
+++ b/kubernetes/apps/home/print-library/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pv.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/home/print-library/app/pv.yaml
+++ b/kubernetes/apps/home/print-library/app/pv.yaml
@@ -1,0 +1,28 @@
+---
+# Static PV — binds to a pre-created directory on the NAS.
+# Pre-step: SSH to NAS and run:
+#   mkdir -p /volume2/kubes/print-library && chown -R 1000:1000 /volume2/kubes/print-library
+# reclaimPolicy: Retain means deleting the PVC will NOT delete the data on disk.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: print-library
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - nconnect=16
+    - hard
+    - noatime
+  csi:
+    driver: nfs.csi.k8s.io
+    # volumeHandle must be unique cluster-wide
+    volumeHandle: print-library
+    volumeAttributes:
+      server: ${NFS_SERVER}
+      share: /volume2/kubes/print-library

--- a/kubernetes/apps/home/print-library/app/pvc.yaml
+++ b/kubernetes/apps/home/print-library/app/pvc.yaml
@@ -1,0 +1,16 @@
+---
+# storageClassName: "" and volumeName: print-library bind this claim explicitly
+# to the static PV above, bypassing the dynamic nfs-slow provisioner.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: print-library
+  namespace: home
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ""
+  volumeName: print-library

--- a/kubernetes/apps/home/print-library/ks.yaml
+++ b/kubernetes/apps/home/print-library/ks.yaml
@@ -2,10 +2,10 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: bambuddy
+  name: print-library
 spec:
   interval: 1h
-  path: ./kubernetes/apps/home/bambuddy/app
+  path: ./kubernetes/apps/home/print-library/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets
@@ -16,6 +16,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: home
-  wait: false
-  dependsOn:
-    - name: print-library
+  wait: true


### PR DESCRIPTION
## Summary

- **New: OrcaSlicer** — `lscr.io/linuxserver/orcaslicer:v2.3.2-ls19` deployed at `orcaslicer.${SECRET_DOMAIN}` (internal-only, `envoy-internal`). Selkies web desktop gives full OrcaSlicer GUI in the browser. Auth via `CUSTOM_USER`/`PASSWORD` from 1Password item `orcaslicer`.
- **New: print-library PV/PVC** — Static NFS PersistentVolume at `${NFS_SERVER}:/volume2/kubes/print-library` (`reclaimPolicy: Retain`). Mounted into both OrcaSlicer (`/config/library`) and Bambuddy (`/app/library`) so sliced output lives on the NAS and survives pod restarts.
- **Updated: Bambuddy** — Bumped `0.2.4` → `v0.2.4.2` (no breaking changes). Added `NET_BIND_SERVICE` capability and exposed ports `990` (FTPS) and `322` (RTSPS) for Proxy Mode, allowing OrcaSlicer to push print jobs through Bambuddy to the A1 via in-cluster DNS (`bambuddy.home.svc.cluster.local`).

## Pre-steps completed (done outside this PR)

- [x] `/volume2/kubes/print-library` created on Atlantis NAS (`0777`, Retain)
- [x] 1Password item `orcaslicer` created in `homeops` vault (username + generated password)

## Post-merge: one-time OrcaSlicer setup

After Flux reconciles, configure the A1 as a virtual printer in OrcaSlicer pointing at Bambuddy's proxy endpoint (`bambuddy.home.svc.cluster.local:990`). All traffic stays in-cluster.

## Test plan

- [ ] `kubectl -n home get pvc print-library` → `Bound` (storageClass empty, volumeName `print-library`)
- [ ] `kubectl -n home get pods` → `orcaslicer-*` and `bambuddy-*` both `Running`
- [ ] Shared mount: drop a file from one pod, confirm visible from the other
- [ ] Browser → `https://orcaslicer.${SECRET_DOMAIN}/` → Selkies login → OrcaSlicer GUI loads
- [ ] Browser → `https://bambuddy.${SECRET_DOMAIN}/` → dashboard loads, Proxy Mode available
- [ ] `kubectl -n home exec deploy/bambuddy -- wget -qO- http://bambuddy.home.svc.cluster.local:8000/health` → 200
- [ ] Confirm no `envoy-external` routes created: `kubectl get httproute -A` shows only `envoy-internal` parentRefs

🤖 Generated with [Claude Code](https://claude.com/claude-code)