### PR TITLE
fix(home): mount existing 3D print folder via static NFS PV

### DIFF
--- a/kubernetes/apps/home/print-library/app/kustomization.yaml
+++ b/kubernetes/apps/home/print-library/app/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./pv.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/home/print-library/app/pv.yaml
+++ b/kubernetes/apps/home/print-library/app/pv.yaml
@@ -1,0 +1,25 @@
+---
+# Static PV binding directly to the existing 3D print folder on Atlantis.
+# NFS export /volume1/syncthing allows 10.0.3.0/24 (k8s node subnet).
+# reclaimPolicy: Retain — deleting the PVC never touches the data on disk.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: print-library
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+  csi:
+    driver: nfs.csi.k8s.io
+    volumeHandle: print-library
+    volumeAttributes:
+      server: ${NFS_SERVER}
+      share: /volume1/syncthing/ic_documents/2 Areas/recreation/3d Print

--- a/kubernetes/apps/home/print-library/app/pvc.yaml
+++ b/kubernetes/apps/home/print-library/app/pvc.yaml
@@ -1,4 +1,6 @@
 ---
+# storageClassName: "" and volumeName: print-library bind explicitly to the
+# static PV above, bypassing the dynamic nfs-slow provisioner.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,4 +12,5 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: nfs-slow
+  storageClassName: ""
+  volumeName: print-library


### PR DESCRIPTION
## Problem

Previous attempts at a shared print-library volume kept failing:
- PR #274: Static PV on `/volume2/kubes/print-library` → `No such file or directory` because `/volume2/kubes` is only exported to `10.0.13.x`, not the `10.0.3.x` k8s nodes
- PR #275: Switched to dynamic `nfs-slow` provisioner → same failure for the same reason

The static PV approach itself was never the problem.

## Fix

Point the static PV directly at the existing 3D print folder:

```
/volume1/syncthing/ic_documents/2 Areas/recreation/3d Print
```

`/volume1/syncthing` is exported to `<internal-ip>/24` ✓ — the k8s nodes can mount it. Existing content in that folder is preserved (`reclaimPolicy: Retain`).

## After merge

The pending dynamic PVC needs to be cleared before Flux can apply the static PV/PVC. Run:
```bash
kubectl -n home patch pvc print-library -p '{"metadata":{"finalizers":[]}}' --type=merge
kubectl -n home delete pvc print-library --wait=false
flux reconcile kustomization print-library -n home
```

## Test plan

- [ ] `kubectl -n home get pvc print-library` → `Bound` to static PV `print-library`
- [ ] `kubectl -n home exec deploy/orcaslicer -- ls /config/library` → shows existing 3D print files
- [ ] Both `orcaslicer-*` and `bambuddy-*` pods `Running`/`Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
