### PR TITLE
fix(home): use subPath for 3D print folder with spaces in name

### DIFF
--- a/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
@@ -84,6 +84,7 @@ spec:
         existingClaim: print-library
         globalMounts:
           - path: /app/library
+            subPath: "ic_documents/2 Areas/Recreation/3D Print"
 
     route:
       app:

--- a/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
@@ -83,6 +83,7 @@ spec:
         existingClaim: print-library
         globalMounts:
           - path: /config/library
+            subPath: "ic_documents/2 Areas/Recreation/3D Print"
 
     route:
       app:

--- a/kubernetes/apps/home/print-library/app/pv.yaml
+++ b/kubernetes/apps/home/print-library/app/pv.yaml
@@ -22,4 +22,6 @@ spec:
     volumeHandle: print-library
     volumeAttributes:
       server: ${NFS_SERVER}
-      share: /volume1/syncthing/ic_documents/2 Areas/recreation/3d Print
+      # Mount the share root — paths with spaces can't be passed as NFS mount args.
+      # The subfolder is accessed via subPath in each app's volumeMount.
+      share: /volume1/syncthing


### PR DESCRIPTION
## Problem

NFS mount arguments can't contain spaces. Setting `share: /volume1/syncthing/ic_documents/2 Areas/Recreation/3D Print` causes the mount command to break on the first space, yielding `No such file or directory`.

Also caught: path was lowercase `recreation/3d Print` — correct capitalisation is `Recreation/3D Print`.

## Fix

- **PV**: mount the share root `share: /volume1/syncthing` (no spaces in NFS arg)
- **OrcaSlicer + Bambuddy HelmReleases**: add `subPath: "ic_documents/2 Areas/Recreation/3D Print"` to the library volumeMount — k8s handles this as a bind mount via Go code, not a shell command, so spaces work correctly

## After merge — cluster cleanup

The stuck terminating PVC needs clearing before Flux can apply the new PV:

```bash
# Delete the orcaslicer pod (releases pvc-protection finalizer)
kubectl -n home delete pod -l app.kubernetes.io/name=orcaslicer
# Strip finalizer and force-delete PVC
kubectl -n home patch pvc print-library -p '{"metadata":{"finalizers":[]}}' --type=merge
kubectl -n home delete pvc print-library --wait=false
# Delete the orphaned static PV too
kubectl delete pv print-library
# Reconcile
flux reconcile kustomization print-library orcaslicer bambuddy -n home
```

## Test plan

- [ ] `kubectl -n home get pvc print-library` → `Bound`, storageClass empty
- [ ] `kubectl -n home exec deploy/orcaslicer -- ls /config/library` → shows existing 3D print files
- [ ] Both pods `Running`/`Ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)