### PR TITLE
fix(home): switch orcaslicer probes to tcpSocket

### DIFF
--- a/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
+++ b/kubernetes/apps/home/orcaslicer/app/helmrelease.yaml
@@ -37,10 +37,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /
+                  tcpSocket:
                     port: 3000
-                    scheme: HTTP
                   initialDelaySeconds: 30
                   periodSeconds: 15
                   failureThreshold: 5
@@ -48,10 +46,8 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /
+                  tcpSocket:
                     port: 3000
-                    scheme: HTTP
                   initialDelaySeconds: 30
                   periodSeconds: 15
                   failureThreshold: 5


### PR DESCRIPTION
## Problem

OrcaSlicer pod is crash-looping. The liveness probe does `httpGet /` on port 3000 but gets `401 Unauthorized` because setting `CUSTOM_USER`/`PASSWORD` enables basic auth on the LSIO Selkies web UI. k8s treats 4xx as probe failure → container killed → restart loop.

## Fix

Switch both liveness and readiness probes to `tcpSocket` on port 3000. This checks the web server is up and accepting connections without needing auth credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)