### PR TITLE
feat(home): add Baby Buddy feeding tracker

### DIFF
--- a/kubernetes/apps/home/babybuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/babybuddy/app/helmrelease.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: babybuddy
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: babybuddy
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: lscr.io/linuxserver/babybuddy
+              tag: v2.9.0-ls232
+            env:
+              TZ: America/New_York
+              PUID: "1000"
+              PGID: "1000"
+              CSRF_TRUSTED_ORIGINS: "https://baby.${SECRET_DOMAIN}"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 8000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8000
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        globalMounts:
+          - path: /config
+
+    route:
+      app:
+        hostnames: ["baby.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: babybuddy
+                port: 8000

--- a/kubernetes/apps/home/babybuddy/app/kustomization.yaml
+++ b/kubernetes/apps/home/babybuddy/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/babybuddy/app/ocirepository.yaml
+++ b/kubernetes/apps/home/babybuddy/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: babybuddy
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/babybuddy/ks.yaml
+++ b/kubernetes/apps/home/babybuddy/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: babybuddy
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/babybuddy/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./bambuddy/ks.yaml
+  - ./babybuddy/ks.yaml
   - ./zwave-js-ui/ks.yaml
   - ./matter-server/ks.yaml
   - ./home-assistant/ks.yaml


### PR DESCRIPTION
## Summary

- Deploys [Baby Buddy](https://github.com/babybuddy/babybuddy) (`lscr.io/linuxserver/babybuddy:v2.9.0-ls232`) to the `home` namespace
- Internal-only route at `baby.${SECRET_DOMAIN}` via `envoy-internal` — no external exposure
- 2Gi Longhorn PVC for `/config` (SQLite database + app data)
- No secrets required; all env vars are non-sensitive (`TZ`, `PUID`/`PGID`, `CSRF_TRUSTED_ORIGINS`)
- Follows identical `app-template` + Flux Kustomization pattern as the rest of the home namespace

## Context

Adding a self-hosted baby tracking app for logging bottle feedings (and diapers, sleep, growth, etc.) for the new baby. The REST API at `/api/feedings/` will be called by Apple Shortcuts for voice logging via Siri on iPhone and HomePod. A HACS Home Assistant integration (`jcgoette/baby_buddy_homeassistant`) will be added in a follow-up to surface sensors and enable feeding reminder automations.

## Test plan

- [ ] Flux reconciles `babybuddy` Kustomization without errors
- [ ] Pod reaches `Running` in `home` namespace, readiness probe passes on `/`
- [ ] `https://baby.${SECRET_DOMAIN}` loads the Baby Buddy login page
- [ ] First-run admin setup completes; child record created; API token generated
- [ ] `POST /api/feedings/` with `Authorization: Token <key>` returns 201

🤖 Generated with [Claude Code](https://claude.com/claude-code)