### PR TITLE
feat(home): allow Baby Buddy to be iframed from Home Assistant

### DIFF
--- a/kubernetes/apps/home/babybuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/babybuddy/app/helmrelease.yaml
@@ -76,3 +76,11 @@ spec:
           - backendRefs:
               - name: babybuddy
                 port: 8000
+            filters:
+              - type: ResponseHeaderModifier
+                responseHeaderModifier:
+                  remove:
+                    - X-Frame-Options
+                  set:
+                    - name: Content-Security-Policy
+                      value: "frame-ancestors https://hass.${SECRET_DOMAIN}"


### PR DESCRIPTION
## Summary

- Removes `X-Frame-Options: DENY` response header via Envoy Gateway `ResponseHeaderModifier` filter
- Sets `Content-Security-Policy: frame-ancestors https://hass.<domain>` so only the HA instance can embed it (not open to the world)
- Enables the Baby Buddy sidebar panel in Home Assistant to load correctly

## Test plan

- [ ] Merge and let Flux reconcile (~1 min)
- [ ] Verify `curl -sI https://baby.example.com | grep -i 'x-frame\|frame-ancestors'` shows no `X-Frame-Options` and the CSP header present
- [ ] Confirm Baby Buddy panel loads in HA sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
