### PR TITLE
feat(home): bump Bambuddy data PVC to 10Gi

### DIFF
--- a/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
+++ b/kubernetes/apps/home/bambuddy/app/helmrelease.yaml
@@ -63,7 +63,7 @@ spec:
         type: persistentVolumeClaim
         storageClass: longhorn
         accessMode: ReadWriteOnce
-        size: 1Gi
+        size: 10Gi
         globalMounts:
           - path: /app/data
 


### PR DESCRIPTION
## What

Increases the Bambuddy `data` PersistentVolumeClaim from **1Gi → 10Gi**.

```yaml
persistence:
  data:
    storageClass: longhorn
    size: 10Gi   # was 1Gi
```

## Why

Bambuddy will be archiving large print files (G-code, 3MF, thumbnails) pushed from OrcaSlicer / Bambu Studio. 1Gi is too tight for robust storage of these.

## Notes / risk

- StorageClass is `longhorn`, which supports online volume expansion (`allowVolumeExpansion: true`). Flux will patch the existing PVC's `spec.resources.requests.storage`; Longhorn expands the volume in place — no data loss, no pod recreation expected.
- Single-file change, isolated branch off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)