### PR TITLE
feat(longhorn): off-cluster PVC backups to Synology NFS

### DIFF
--- a/docs/longhorn-backup-restore.md
+++ b/docs/longhorn-backup-restore.md
@@ -1,0 +1,67 @@
+# Longhorn Backup & Restore Runbook
+
+Off-cluster backups for all PVCs use **Longhorn native backups → Synology NFS**.
+Incremental, block-level, with zero always-on cluster footprint between scheduled runs.
+Cluster *manifests* are not backed up here on purpose — they're reproducible from this
+GitOps repo (Flux). Only PVC **data** needs backing up.
+
+## Topology
+
+- **Backup target:** `nfs://10.0.3.2:/volume2/longhorn-backup` (Synology, NFSv4, no creds)
+- **Config:** `kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml` (`defaultSettings.backupTarget`)
+- **Schedules:** `kubernetes/apps/longhorn-system/longhorn/app/recurringjobs.yaml`
+  - `snapshot-hourly` — local snapshot every 6h, retain 8 (fast rollback)
+  - `backup-daily` — backup to NFS daily 03:00, retain 7
+  - `backup-weekly` — backup to NFS weekly Sun 04:00, retain 4
+- All jobs are in the Longhorn `default` group, so they auto-apply to every volume
+  (current and future) that has no volume-specific recurring jobs.
+
+## Synology prerequisite (one-time)
+
+1. Create shared folder `/volume2/longhorn-backup`.
+2. NFS export: NFSv4.1 enabled, `rw` + `no_root_squash` (or map-to-admin),
+   granted to node IPs `10.0.3.21/22/23` (or `10.0.3.0/24`).
+3. Optional: ~300 GB quota.
+
+## Verify backups are working
+
+```sh
+# Backup target healthy?
+kubectl -n longhorn-system get backuptarget default -o yaml
+
+# Recurring jobs present
+kubectl -n longhorn-system get recurringjobs.longhorn.io
+
+# Backups accumulating (after first scheduled run, or trigger one from the UI)
+kubectl -n longhorn-system get backups.longhorn.io
+```
+
+Or use the Longhorn UI (HTTPRoute) → Backup tab.
+
+## Restore a single volume
+
+1. Longhorn UI → **Backup** → select the volume's backup → **Restore Latest Backup**
+   (or a specific point in time). Restore into a new Longhorn volume.
+2. Create a PV/PVC bound to the restored volume (use `longhorn-static` StorageClass,
+   or the UI "Create PV/PVC" action on the restored volume).
+3. Point the workload's PVC at it, or rename to match the original PVC.
+
+CLI alternative: create a `Volume` CR with `spec.fromBackup` set to the backup URL,
+then create the matching PV/PVC.
+
+## Full cluster-rebuild disaster recovery
+
+1. Stand up a fresh Talos cluster and bootstrap Flux against this repo.
+2. Flux reinstalls Longhorn from `helmrelease.yaml`, which sets the **same backup target**.
+3. Longhorn reads the self-describing backupstore on the NFS share — all existing
+   backups reappear under **Backup** automatically.
+4. For each app, restore its volume from backup (see above) and create the PV/PVC the
+   app's manifests expect. Git rebuilds the apps; NFS rebuilds the data.
+
+## Notes / limitations
+
+- NFS backups are **crash-consistent** (fine for SQLite/config; Postgres recovers via
+  WAL replay). `freezeFilesystemForSnapshot: true` tightens this.
+- **Phase 2** adds logically consistent DB dumps (`pg_dump` CronJobs) for stateful DB
+  apps as defense-in-depth — see the project note in the LifeOS vault.
+- Consider a periodic restore drill and off-site replication of the NFS folder (3-2-1).

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -31,6 +31,15 @@ spec:
       snapshotDataIntegrity: enabled
       snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true
       fastReplicaRebuildEnabled: true
+      # Off-cluster backup target: Synology NFS (NFSv4). No credentials needed for NFS.
+      # Backups are incremental block-level; recurring schedules live in recurringjobs.yaml.
+      backupTarget: nfs://10.0.3.2:/volume2/longhorn-backup
+      backupTargetCredentialSecret: ""
+      # Cap concurrency so scheduled backups/restores never spike cluster load.
+      backupConcurrentLimit: 2
+      restoreConcurrentLimit: 2
+      # Freeze the filesystem during snapshot for a more consistent point-in-time copy.
+      freezeFilesystemForSnapshot: true
 
     # Enable persistent storage
     persistence:

--- a/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrelease.yaml
   - ./helmrepository.yaml
   - ./httproute.yaml
+  - ./recurringjobs.yaml

--- a/kubernetes/apps/longhorn-system/longhorn/app/recurringjobs.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/recurringjobs.yaml
@@ -1,0 +1,47 @@
+---
+# Recurring jobs in the "default" group automatically apply to every Longhorn
+# volume that has no volume-specific recurring jobs — i.e. all current volumes
+# AND any future PVC, with zero per-app configuration.
+#
+# Layered strategy:
+#   - snapshot-hourly : fast same-cluster rollback (local, cheap)
+#   - backup-daily    : off-box DR to Synology NFS, 1 week of daily points
+#   - backup-weekly   : longer history (~1 month) via cheap incrementals
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: snapshot-hourly
+  namespace: longhorn-system
+spec:
+  cron: "0 */6 * * *"   # every 6 hours
+  task: snapshot
+  groups:
+    - default
+  retain: 8             # keep last 8 snapshots (~2 days)
+  concurrency: 2
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: backup-daily
+  namespace: longhorn-system
+spec:
+  cron: "0 3 * * *"     # daily at 03:00
+  task: backup
+  groups:
+    - default
+  retain: 7             # keep last 7 daily backups
+  concurrency: 2
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: backup-weekly
+  namespace: longhorn-system
+spec:
+  cron: "0 4 * * 0"     # weekly, Sunday 04:00
+  task: backup
+  groups:
+    - default
+  retain: 4             # keep last 4 weekly backups (~1 month)
+  concurrency: 2


### PR DESCRIPTION
## Summary

Establishes a resource-light, off-cluster backup strategy for **all** Longhorn PVCs (44 volumes, ~91 GB live data). Since the cluster is fully GitOps-managed by Flux, manifests are already backed up — only PVC **data** needs protecting. This avoids Velero's always-on node-agent and uses Longhorn's native incremental block-level backups to the existing Synology NFS.

**Zero always-on cluster footprint** — backup pods spin up only during scheduled runs, capped at 2 concurrent.

## Changes

- **`helmrelease.yaml`** — set `backupTarget: nfs://<internal-ip>:/volume2/longhorn-backup` (no creds needed for NFS), cap `backupConcurrentLimit`/`restoreConcurrentLimit` at 2, enable `freezeFilesystemForSnapshot`.
- **`recurringjobs.yaml`** — three `default`-group RecurringJobs (auto-apply to all current + future volumes):
  | Job | Schedule | Retain | Purpose |
  |---|---|---|---|
  | `snapshot-hourly` | every 6h | 8 | fast same-cluster rollback (local) |
  | `backup-daily` | daily 03:00 | 7 | off-box DR, 1 week of points |
  | `backup-weekly` | Sun 04:00 | 4 | ~1 month history (cheap incrementals) |
- **`docs/longhorn-backup-restore.md`** — DR runbook (verify, single-volume restore, full cluster-rebuild recovery).

## ⚠️ Required before merge takes effect (manual, on Synology)

1. Create shared folder `/volume2/longhorn-backup`.
2. NFS export: NFSv4.1, `rw` + `no_root_squash` (or map-to-admin), grant to `<internal-ip>/22/23` (or `<internal-ip>/24`).
3. Optional ~300 GB quota.

## Validation

- `kubectl kustomize ...app` builds clean.
- `kubectl apply --dry-run=server` accepted all three RecurringJob CRs against the live cluster.

## Follow-up

Phase 2 — logically consistent DB dumps (`pg_dump` CronJobs) for Authentik / Nextcloud / Zipline / Grimmory / TeslaMate Postgres + Qdrant snapshots. Tracked in the LifeOS project note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
