### PR TITLE
fix(longhorn): set backup target via defaultBackupStore

### DIFF
--- a/docs/longhorn-backup-restore.md
+++ b/docs/longhorn-backup-restore.md
@@ -8,7 +8,7 @@ GitOps repo (Flux). Only PVC **data** needs backing up.
 ## Topology
 
 - **Backup target:** `nfs://10.0.3.2:/volume2/longhorn-backup` (Synology, NFSv4, no creds)
-- **Config:** `kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml` (`defaultSettings.backupTarget`)
+- **Config:** `kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml` (`defaultBackupStore.backupTarget` — Longhorn v1.11 moved this off `defaultSettings` onto the `default` BackupTarget CR)
 - **Schedules:** `kubernetes/apps/longhorn-system/longhorn/app/recurringjobs.yaml`
   - `snapshot-hourly` — local snapshot every 6h, retain 8 (fast rollback)
   - `backup-daily` — backup to NFS daily 03:00, retain 7

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -31,15 +31,20 @@ spec:
       snapshotDataIntegrity: enabled
       snapshotDataIntegrityImmediateCheckAfterSnapshotCreation: true
       fastReplicaRebuildEnabled: true
-      # Off-cluster backup target: Synology NFS (NFSv4). No credentials needed for NFS.
-      # Backups are incremental block-level; recurring schedules live in recurringjobs.yaml.
-      backupTarget: nfs://10.0.3.2:/volume2/longhorn-backup
-      backupTargetCredentialSecret: ""
       # Cap concurrency so scheduled backups/restores never spike cluster load.
       backupConcurrentLimit: 2
       restoreConcurrentLimit: 2
       # Freeze the filesystem during snapshot for a more consistent point-in-time copy.
       freezeFilesystemForSnapshot: true
+
+    # Off-cluster backup target: Synology NFS (NFSv4). No credentials needed for NFS.
+    # In Longhorn v1.11 the backup target is the `defaultBackupStore` chart block
+    # (it populates the `default` BackupTarget CR) — NOT defaultSettings.backupTarget,
+    # which was removed as a setting in this version and is silently ignored.
+    defaultBackupStore:
+      backupTarget: nfs://10.0.3.2:/volume2/longhorn-backup
+      backupTargetCredentialSecret: ""
+      pollInterval: 300
 
     # Enable persistent storage
     persistence:


### PR DESCRIPTION
## Problem

After #284 merged, Flux reconciled cleanly and the RecurringJobs + concurrency/freeze settings applied — but the **backup target never took**:

```
$ kubectl -n longhorn-system get backuptarget default
AVAILABLE=false   MSG="backup target URL is empty"
$ kubectl -n longhorn-system get settings.longhorn.io backup-target
Error: settings.longhorn.io "backup-target" not found
```

Longhorn v1.11 **removed** the `backup-target` global Setting and now manages the target through the `default` `BackupTarget` CR. The Helm chart populates that CR via the `defaultBackupStore` values block — `defaultSettings.backupTarget` (what #284 used) is silently ignored.

## Fix

Move `backupTarget` / `backupTargetCredentialSecret` into a `defaultBackupStore:` block, add `pollInterval: 300`. The concurrency caps and `freezeFilesystemForSnapshot` stay in `defaultSettings` — those applied correctly and are unchanged. Runbook reference updated.

## Validation

- `kubectl kustomize ...app` builds clean.
- Post-merge check will confirm `kubectl -n longhorn-system get backuptarget default` reports `AVAILABLE=true` (which also proves the Synology NFS export is reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)