### PR TITLE
fix: remove dead LiteLLM references from LibreChat and Homepage

### DIFF
--- a/kubernetes/apps/ai/librechat/app/configmap.yaml
+++ b/kubernetes/apps/ai/librechat/app/configmap.yaml
@@ -9,9 +9,9 @@ data:
     cache: true
     endpoints:
       custom:
-        - name: "Ollama (via LiteLLM)"
-          apiKey: "${LITELLM_MASTER_KEY}"
-          baseURL: "http://litellm-main.ai.svc.cluster.local:4000"
+        - name: "Ollama"
+          apiKey: "ollama"
+          baseURL: "http://ollama.ai.svc.cluster.local:11434/v1"
           models:
             default: ["llama3.2", "phi3"]
             fetch: false

--- a/kubernetes/apps/tools/homepage/app/configmap.yaml
+++ b/kubernetes/apps/tools/homepage/app/configmap.yaml
@@ -192,10 +192,6 @@ data:
             icon: n8n.svg
             href: https://n8n.${SECRET_DOMAIN}
             description: Automation
-        - LiteLLM:
-            icon: sh-litellm
-            href: https://llm.${SECRET_DOMAIN}
-            description: LLM Proxy
 
   custom.css: |
     /* Catppuccin Mocha — Mauve accent */


### PR DESCRIPTION
## Summary

LiteLLM was removed from the cluster (commented out of `kubernetes/apps/ai/kustomization.yaml`). Two configs still pointed at the dead service.

- **LibreChat** (`kubernetes/apps/ai/librechat/app/configmap.yaml`): Repoints the Ollama endpoint directly at `http://ollama.ai.svc.cluster.local:11434/v1`. Updates the endpoint name from "Ollama (via LiteLLM)" to "Ollama". Replaces the dead `LITELLM_MASTER_KEY` apiKey with the dummy `"ollama"` value (Ollama requires no auth; LibreChat custom endpoints require a non-empty apiKey field).
- **Homepage** (`kubernetes/apps/tools/homepage/app/configmap.yaml`): Removes the LiteLLM tile from the AI section. No replacement added.

## ExternalSecret note

The LibreChat `externalsecret.yaml` uses `dataFrom: extract: key: librechat` — it pulls the entire 1Password item as a batch. `LITELLM_MASTER_KEY` may still exist as a field in that item, but it is no longer consumed by the configmap. The externalsecret is left untouched to avoid risk of disrupting other keys in the same item extract.

## Validation

- `yamllint -c .yamllint.yaml` passes clean on both edited files.
- `kubeconform` not installed locally; `task validate:static` yamllint stage confirmed clean.

## Test plan

- [ ] Confirm Flux reconciles the `librechat` and `homepage` kustomizations without errors
- [ ] Open LibreChat — verify "Ollama" endpoint appears and can reach models (llama3.2, phi3)
- [ ] Open Homepage — confirm LiteLLM tile is gone from the AI section, other tiles unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)