### PR TITLE
fix(ai/ori-agent): exempt bootstrap ConfigMap from Flux substitution

### DIFF
--- a/kubernetes/apps/ai/ori-agent/app/configmap.yaml
+++ b/kubernetes/apps/ai/ori-agent/app/configmap.yaml
@@ -14,6 +14,12 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ori-agent-bootstrap
+  annotations:
+    # The bootstrap script is full of shell ${VAR} refs. The parent ks.yaml runs
+    # Flux postBuild substituteFrom (for ${ORI_AGENT_LB_IP}/${SECRET_DOMAIN}/${NFS_SERVER}
+    # in the HelmRelease), which would otherwise blank every unknown ${VAR} here.
+    # Opt this object out so the script reaches the pod verbatim.
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 data:
   authorized_keys: |
     ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICj962t+RwZGIrcycomEDvbgWAoiFVQT9X6YIvJMVPaX shawn@mac


### PR DESCRIPTION
Second crashloop cause. The bootstrap script's shell `${HOME_DIR}`/`${LOCAL_BIN}`/`${NPM_PREFIX}` refs were being blanked by Flux `postBuild` substitution (which the parent ks.yaml runs for `${ORI_AGENT_LB_IP}`/`${SECRET_DOMAIN}`/`${NFS_SERVER}` in the HelmRelease). Result: `mkdir ''` → exit 1.

Fix: `kustomize.toolkit.fluxcd.io/substitute: disabled` on the ConfigMap so the script reaches the pod verbatim. The HelmRelease still gets its substitutions.

Verified against the in-cluster ConfigMap (`LOCAL_BIN="/.local/bin"` ← the bug). `validate:flux` 127 passed.