### PR TITLE
chore(atuin): disable open registration

### DIFF
--- a/kubernetes/apps/tools/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/atuin/app/helmrelease.yaml
@@ -23,7 +23,7 @@ spec:
             env:
               ATUIN_HOST: 0.0.0.0
               ATUIN_PORT: "8888"
-              ATUIN_OPEN_REGISTRATION: "true"
+              ATUIN_OPEN_REGISTRATION: "false"
               RUST_LOG: info
               ATUIN_DB_URI:
                 valueFrom:


### PR DESCRIPTION
## What
Flip `ATUIN_OPEN_REGISTRATION` from `"true"` → `"false"` on the self-hosted atuin sync server.

## Why
Open registration was only on to bootstrap the first account. That account now exists (creds + encryption key stored in 1Password), so registration should be closed to prevent any new accounts being created on the internal-routed server.

## Impact
- Existing account + history sync: **unaffected**.
- New `atuin register` against this server: **blocked** (intended).
- Single env var change; Flux will roll the `atuin-main` deployment on reconcile.

## Validation after merge
- Flux reconciles `tools/atuin`, pod restarts healthy.
- `atuin login` / `atuin sync` from an enrolled machine still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)