### PR TITLE
feat(renovate): Discord completion notification after triage

### DIFF
--- a/docs/database-dumps-restore.md
+++ b/docs/database-dumps-restore.md
@@ -1,0 +1,100 @@
+# Database Logical Dumps & Restore Runbook
+
+**Phase 2** of the cluster backup strategy. Adds application-level, logically consistent
+dumps for every stateful database, layered on top of Phase 1's crash-consistent Longhorn
+block backups (see `longhorn-backup-restore.md`). Logical dumps are portable, version-aware,
+and immune to the "block snapshot caught the DB mid-write" failure mode.
+
+## How it works
+
+- One `CronJob` per database, in the **same namespace as the app**, reusing the app's
+  existing ExternalSecret for credentials (no credential duplication).
+- Each namespace with DBs has a dedicated **`db-backups` Longhorn PVC** that the dumps
+  write to. Phase 1's `default`-group RecurringJob automatically backs that PVC off-box to
+  Synology NFS — so logical dumps inherit off-site DR for free, no extra wiring.
+- Dumps run nightly, **staggered 01:00–02:30**, ahead of Phase 1's 03:00 `backup-daily` so
+  fresh dumps are captured the same night.
+- **Retention:** 14 days per DB, self-pruned in-job (`find -mtime +14 -delete`).
+- Manifests: `kubernetes/apps/<ns>/db-backup/` (PVC + CronJobs + Flux Kustomization).
+
+## Coverage
+
+| App | NS | Engine | Dump file | Method |
+|-----|----|--------|-----------|--------|
+| authentik | security | Postgres 17 | `authentik-*.dump` | `pg_dump -Fc` |
+| atuin | tools | Postgres 18 | `atuin-*.dump` | `pg_dump -Fc` |
+| nextcloud | tools | Postgres 18 | `nextcloud-*.dump` | `pg_dump -Fc` |
+| shlink | tools | Postgres 18 | `shlink-*.dump` | `pg_dump -Fc` |
+| zipline | tools | Postgres 18 | `zipline-*.dump` | `pg_dump -Fc` |
+| teslamate | home | Postgres 18 | `teslamate-*.dump` | `pg_dump -Fc` |
+| grimmory | media | MariaDB 12 | `grimmory-*.sql.gz` | `mariadb-dump \| gzip` |
+| n8n | ai | Postgres 18 | `n8n-*.dump` | `pg_dump -Fc` |
+| librechat | ai | MongoDB 8.3 | `librechat-*.archive.gz` | `mongodump --gzip --archive` |
+| qdrant | ai | Qdrant 1.18 | `qdrant-*-<snapshot>` | snapshot API → download |
+
+**Not covered here:** `forgejo` (HelmRelease declares postgres but no DB workload exists in
+cluster — its data lives on its own block-backed PVC); `litellm` (removed 2026-05).
+
+## Verify dumps are working
+
+```sh
+# CronJobs present
+kubectl get cronjobs -A | grep db-backup
+
+# Manually trigger a one-off run (no need to wait for schedule)
+kubectl -n <ns> create job --from=cronjob/db-backup-<app> manual-<app>-test
+
+# Watch it
+kubectl -n <ns> logs -f job/manual-<app>-test
+
+# Inspect dump files on the PVC (spin a throwaway pod that mounts it)
+kubectl -n <ns> run pvc-peek --rm -it --restart=Never --image=busybox \
+  --overrides='{"spec":{"containers":[{"name":"pvc-peek","image":"busybox","command":["ls","-lh","/backups"],"volumeMounts":[{"name":"b","mountPath":"/backups"}]}],"volumes":[{"name":"b","persistentVolumeClaim":{"claimName":"db-backups"}}]}}'
+```
+
+## Restore a single database
+
+First, copy the desired dump off the PVC (mount it in a throwaway pod, or restore the PVC
+from Longhorn backup if the cluster is gone — see `longhorn-backup-restore.md`).
+
+**Postgres** (custom format `-Fc`):
+```sh
+# into the live DB (drops/recreates objects)
+pg_restore --clean --if-exists --no-owner --no-privileges \
+  -d "postgres://<user>:<pw>@<svc>:5432/<db>" /path/<app>-<ts>.dump
+```
+
+**MariaDB**:
+```sh
+gunzip -c /path/grimmory-<ts>.sql.gz | \
+  mariadb -h grimmory-mariadb.media.svc.cluster.local -u grimmory -p<pw> grimmory
+```
+
+**MongoDB**:
+```sh
+mongorestore --uri="<mongo_uri>" --gzip --archive=/path/librechat-<ts>.archive.gz --drop
+```
+
+**Qdrant** (snapshot file):
+```sh
+# upload + recover a collection from a downloaded snapshot
+curl -X POST -H "api-key: <api_key>" \
+  -F "snapshot=@/path/qdrant-<ts>-<name>" \
+  "http://qdrant.ai.svc.cluster.local:6333/collections/<collection>/snapshots/upload?priority=snapshot"
+```
+
+## Full disaster recovery order of operations
+
+1. Rebuild cluster + Flux (Git restores all manifests, incl. these CronJobs).
+2. Restore each app's **data PVC** from Longhorn NFS backup (block-level) — gets apps running.
+3. For databases, optionally **replay the latest logical dump** over the restored DB if the
+   block restore was mid-write / inconsistent. Logical dump is the authoritative,
+   point-in-consistency copy.
+4. The `db-backups` PVCs themselves are restorable from Longhorn NFS too — that's where the
+   dump history lives off-box.
+
+## Notes
+
+- pg_dump client is 18 (dumps Postgres 17 and 18 servers; forward-compatible).
+- All jobs run restricted-PSA compliant (non-root uid 1000, dropped caps, seccomp default).
+- Consider a quarterly restore drill to prove dumps are good.

--- a/docs/longhorn-backup-restore.md
+++ b/docs/longhorn-backup-restore.md
@@ -62,6 +62,7 @@ then create the matching PV/PVC.
 
 - NFS backups are **crash-consistent** (fine for SQLite/config; Postgres recovers via
   WAL replay). `freezeFilesystemForSnapshot: true` tightens this.
-- **Phase 2** adds logically consistent DB dumps (`pg_dump` CronJobs) for stateful DB
-  apps as defense-in-depth — see the project note in the LifeOS vault.
+- **Phase 2** adds logically consistent DB dumps (`pg_dump`/`mariadb-dump`/`mongodump`/
+  Qdrant-snapshot CronJobs) for stateful DB apps as defense-in-depth — see
+  `database-dumps-restore.md`.
 - Consider a periodic restore drill and off-site replication of the NFS folder (3-2-1).

--- a/kubernetes/apps/ai/db-backup/app/cronjob-librechat.yaml
+++ b/kubernetes/apps/ai/db-backup/app/cronjob-librechat.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-librechat
+spec:
+  schedule: "20 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: mongo:8.3
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: MONGO_URI
+                valueFrom:
+                  secretKeyRef:
+                    name: librechat-secret
+                    key: mongo_uri
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/librechat-${TS}.archive.gz"
+                  echo "[$(date -u)] mongodump librechat -> ${OUT}"
+                  mongodump --uri="${MONGO_URI}" --gzip --archive="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning librechat-*.archive.gz older than ${RETENTION_DAYS}d"
+                  find /backups -name 'librechat-*.archive.gz' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/ai/db-backup/app/cronjob-n8n.yaml
+++ b/kubernetes/apps/ai/db-backup/app/cronjob-n8n.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-n8n
+spec:
+  schedule: "10 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secret
+                    key: db_password
+              - name: PGHOST
+                value: n8n-postgres.ai.svc.cluster.local
+              - name: PGUSER
+                value: n8n
+              - name: PGDATABASE
+                value: n8n
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/n8n-${TS}.dump"
+                  echo "[$(date -u)] pg_dump n8n -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning n8n-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'n8n-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/ai/db-backup/app/cronjob-qdrant.yaml
+++ b/kubernetes/apps/ai/db-backup/app/cronjob-qdrant.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-qdrant
+spec:
+  schedule: "30 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: python:3.12-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: QDRANT_API_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: qdrant-secret
+                    key: api_key
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  python3 - <<'PY'
+                  import os, json, glob, time, urllib.request
+                  base = "http://qdrant.ai.svc.cluster.local:6333"
+                  key = os.environ["QDRANT_API_KEY"]
+                  ret = int(os.environ.get("RETENTION_DAYS", "14"))
+                  def call(method, path, raw=False):
+                      req = urllib.request.Request(base + path, method=method, headers={"api-key": key})
+                      r = urllib.request.urlopen(req, timeout=300)
+                      return r.read() if raw else json.loads(r.read())
+                  ts = time.strftime("%Y%m%d-%H%M%S")
+                  print("Creating full Qdrant snapshot...", flush=True)
+                  res = call("POST", "/snapshots")
+                  name = res["result"]["name"]
+                  print("snapshot:", name, flush=True)
+                  data = call("GET", "/snapshots/" + name, raw=True)
+                  out = "/backups/qdrant-%s-%s" % (ts, name)
+                  with open(out, "wb") as f:
+                      f.write(data)
+                  print("wrote", out, os.path.getsize(out), "bytes", flush=True)
+                  # delete server-side snapshot so qdrant PVC does not grow
+                  try:
+                      call("DELETE", "/snapshots/" + name)
+                      print("deleted server-side snapshot", flush=True)
+                  except Exception as e:
+                      print("warn: could not delete server snapshot:", e, flush=True)
+                  # prune local
+                  cutoff = time.time() - ret * 86400
+                  for p in glob.glob("/backups/qdrant-*"):
+                      if os.path.getmtime(p) < cutoff:
+                          os.remove(p); print("pruned", p, flush=True)
+                  print("done", flush=True)
+                  PY
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/ai/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/ai/db-backup/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-n8n.yaml
+  - ./cronjob-librechat.yaml
+  - ./cronjob-qdrant.yaml

--- a/kubernetes/apps/ai/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/ai/db-backup/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/ai/db-backup/ks.yaml
+++ b/kubernetes/apps/ai/db-backup/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/db-backup/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./db-backup/ks.yaml
   # - ./litellm/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml

--- a/kubernetes/apps/home/db-backup/app/cronjob-teslamate.yaml
+++ b/kubernetes/apps/home/db-backup/app/cronjob-teslamate.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-teslamate
+spec:
+  schedule: "50 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: teslamate-secret
+                    key: db_password
+              - name: PGHOST
+                value: teslamate-postgres.home.svc.cluster.local
+              - name: PGUSER
+                value: teslamate
+              - name: PGDATABASE
+                value: teslamate
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/teslamate-${TS}.dump"
+                  echo "[$(date -u)] pg_dump teslamate -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning teslamate-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'teslamate-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/home/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/home/db-backup/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-teslamate.yaml

--- a/kubernetes/apps/home/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/home/db-backup/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 3Gi

--- a/kubernetes/apps/home/db-backup/ks.yaml
+++ b/kubernetes/apps/home/db-backup/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/home/db-backup/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: home
+  wait: false

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./db-backup/ks.yaml
   - ./bambuddy/ks.yaml
   - ./babybuddy/ks.yaml
   - ./zwave-js-ui/ks.yaml

--- a/kubernetes/apps/media/db-backup/app/cronjob-grimmory.yaml
+++ b/kubernetes/apps/media/db-backup/app/cronjob-grimmory.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-grimmory
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: mariadb:12
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: MYSQL_PWD
+                valueFrom:
+                  secretKeyRef:
+                    name: grimmory-secret
+                    key: DB_PASSWORD
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  set -euo pipefail
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/grimmory-${TS}.sql.gz"
+                  echo "[$(date -u)] mariadb-dump grimmory -> ${OUT}"
+                  mariadb-dump --single-transaction --no-tablespaces --skip-lock-tables \
+                    -h grimmory-mariadb.media.svc.cluster.local -u grimmory grimmory | gzip -9 > "${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning grimmory-*.sql.gz older than ${RETENTION_DAYS}d"
+                  find /backups -name 'grimmory-*.sql.gz' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/media/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/media/db-backup/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-grimmory.yaml

--- a/kubernetes/apps/media/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/media/db-backup/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/media/db-backup/ks.yaml
+++ b/kubernetes/apps/media/db-backup/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/media/db-backup/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./db-backup/ks.yaml
   - ./metube/ks.yaml
   - ./seerr/ks.yaml
   - ./prowlarr/ks.yaml

--- a/kubernetes/apps/security/db-backup/app/cronjob-authentik.yaml
+++ b/kubernetes/apps/security/db-backup/app/cronjob-authentik.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-authentik
+spec:
+  schedule: "0 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: authentik-secret
+                    key: AUTHENTIK_DB_PASSWORD
+              - name: PGHOST
+                value: authentik-postgresql.security.svc.cluster.local
+              - name: PGUSER
+                value: authentik
+              - name: PGDATABASE
+                value: authentik
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/authentik-${TS}.dump"
+                  echo "[$(date -u)] pg_dump authentik -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning authentik-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'authentik-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/security/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/security/db-backup/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-authentik.yaml

--- a/kubernetes/apps/security/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/security/db-backup/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 3Gi

--- a/kubernetes/apps/security/db-backup/ks.yaml
+++ b/kubernetes/apps/security/db-backup/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/security/db-backup/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: security
+  wait: false

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./db-backup/ks.yaml
   - ./onepassword-connect/ks.yaml
   - ./external-secrets/ks.yaml
   - ./authentik/ks.yaml

--- a/kubernetes/apps/tools/db-backup/app/cronjob-atuin.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-atuin.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-atuin
+spec:
+  schedule: "10 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: atuin-secret
+                    key: database_url
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/atuin-${TS}.dump"
+                  echo "[$(date -u)] pg_dump atuin (url) -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}" "${DATABASE_URL}"
+                  ls -lh "${OUT}"
+                  echo "Pruning atuin-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'atuin-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/cronjob-nextcloud.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-nextcloud.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-nextcloud
+spec:
+  schedule: "20 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: nextcloud-secret
+                    key: db_password
+              - name: PGHOST
+                value: nextcloud-postgres.tools.svc.cluster.local
+              - name: PGUSER
+                value: nextcloud
+              - name: PGDATABASE
+                value: nextcloud
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/nextcloud-${TS}.dump"
+                  echo "[$(date -u)] pg_dump nextcloud -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning nextcloud-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'nextcloud-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/cronjob-shlink.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-shlink.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-shlink
+spec:
+  schedule: "30 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: shlink-secret
+                    key: db_password
+              - name: PGHOST
+                value: shlink-postgres.tools.svc.cluster.local
+              - name: PGUSER
+                value: shlink
+              - name: PGDATABASE
+                value: shlink
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/shlink-${TS}.dump"
+                  echo "[$(date -u)] pg_dump shlink -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning shlink-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'shlink-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/cronjob-zipline.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-zipline.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-zipline
+spec:
+  schedule: "40 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: zipline-secret
+                    key: DATABASE_URL
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/zipline-${TS}.dump"
+                  echo "[$(date -u)] pg_dump zipline (url) -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}" "${DATABASE_URL}"
+                  ls -lh "${OUT}"
+                  echo "Pruning zipline-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'zipline-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/tools/db-backup/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-atuin.yaml
+  - ./cronjob-nextcloud.yaml
+  - ./cronjob-shlink.yaml
+  - ./cronjob-zipline.yaml

--- a/kubernetes/apps/tools/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/tools/db-backup/app/pvc.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/tools/db-backup/ks.yaml
+++ b/kubernetes/apps/tools/db-backup/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/db-backup/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -8,6 +8,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./db-backup/ks.yaml
   - ./forgejo/ks.yaml
   - ./shlink/ks.yaml
   - ./apprise/ks.yaml

--- a/scripts/renovate-triage/triage.py
+++ b/scripts/renovate-triage/triage.py
@@ -19,6 +19,13 @@ Usage:
   triage.py --verify-health        # just run the cluster health check (no triage/merge)
   triage.py --repo owner/repo      # override repo
 
+Completion notification (Discord):
+  On a real --merge-safe run, after the merge + health check settle, a summary is
+  POSTed to a Discord channel webhook (success / cluster-degraded / nothing-to-merge).
+  The webhook URL comes from --discord-webhook or the RENOVATE_DISCORD_WEBHOOK env
+  var; if neither is set the notify step is skipped (the run is unaffected).
+  --no-notify suppresses it; --dry-run prints the payload instead of POSTing.
+
 Cluster health check (after a real merge, or via --verify-health):
   Merged PRs land on main; Flux reconciles the change onto the cluster. Before
   declaring the run complete we nudge Flux and poll until the GitOps state settles:
@@ -29,9 +36,12 @@ Cluster health check (after a real merge, or via --verify-health):
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 
 REPO = "1activegeek/home-ops"
@@ -180,6 +190,91 @@ def run_gh_merge(pr_number, repo, dry_run):
         print(f"  Merge failed: {r2.stderr.strip()}", file=sys.stderr)
         return False
     return True
+
+
+# --- completion notification (Discord) -------------------------------------
+
+# Discord embed accent colors (decimal RGB).
+DISCORD_GREEN = 3066993    # merged cleanly, cluster settled
+DISCORD_ORANGE = 15105570  # merged but health check skipped
+DISCORD_RED = 15158332     # cluster did not settle
+DISCORD_BLUE = 3447003     # ran, nothing to merge
+
+
+def _pr_lines(entries, limit=12):
+    """Markdown bullet list of PRs for a Discord embed (capped)."""
+    lines = [f"• [#{e['number']}]({e['url']}) {e['title']}" for e in entries[:limit]]
+    if len(entries) > limit:
+        lines.append(f"• …and {len(entries) - limit} more")
+    return "\n".join(lines)
+
+
+def build_notification(buckets, merged, health, skip_health):
+    """Return (title, color, description) summarizing a --merge-safe run."""
+    review = buckets["review"]
+    waiting = buckets["waiting"]
+    blocked = buckets["blocked"]
+
+    if health is not None and not health.get("healthy"):
+        title = "⚠️ Renovate triage — cluster did NOT settle"
+        color = DISCORD_RED
+    elif merged:
+        title = f"✅ Renovate triage — merged {len(merged)} PR(s)"
+        color = DISCORD_ORANGE if skip_health else DISCORD_GREEN
+    else:
+        title = "ℹ️ Renovate triage — nothing to merge"
+        color = DISCORD_BLUE
+
+    parts = []
+    if merged:
+        parts.append(f"**Merged ({len(merged)})**\n{_pr_lines(merged)}")
+    if review:
+        parts.append(f"**Needs review — majors ({len(review)})**\n{_pr_lines(review)}")
+    if waiting:
+        parts.append(f"**Waiting on CI ({len(waiting)})**\n{_pr_lines(waiting)}")
+    if blocked:
+        parts.append(f"**Blocked ({len(blocked)})**\n{_pr_lines(blocked)}")
+    if health is not None:
+        if health.get("healthy"):
+            parts.append("**Cluster:** settled ✅")
+        else:
+            parts.append(f"**Cluster:** {health.get('error', 'degraded')} ⚠️")
+    elif merged and skip_health:
+        parts.append("**Cluster:** health check skipped (--skip-health-check)")
+    if not parts:
+        parts.append("No open Renovate PRs.")
+    return title, color, "\n\n".join(parts)
+
+
+def notify_discord(webhook_url, title, color, description, dry_run=False):
+    """POST a summary embed to a Discord channel webhook. Best-effort; never raises."""
+    payload = {"embeds": [{
+        "title": title,
+        "description": description[:4000],  # Discord embed description hard cap
+        "color": color,
+    }]}
+    if dry_run:
+        print("  [dry-run] would POST to Discord webhook:\n"
+              f"{json.dumps(payload, indent=2)}", file=sys.stderr)
+        return True
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        webhook_url, data=data,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            if 200 <= resp.status < 300:
+                print(f"  notify: Discord notification sent ({resp.status}).",
+                      file=sys.stderr)
+                return True
+            print(f"  notify: Discord returned HTTP {resp.status}", file=sys.stderr)
+            return False
+    except OSError as e:
+        # URLError and socket TimeoutError are both OSError subclasses — catch the
+        # base so a flaky webhook never fails the triage run.
+        print(f"  notify: Discord POST failed: {e}", file=sys.stderr)
+        return False
 
 
 # --- cluster health verification -------------------------------------------
@@ -342,6 +437,11 @@ def main():
                         help="merge but don't wait for the cluster to settle")
     parser.add_argument("--health-timeout", type=int, default=HEALTH_TIMEOUT_S,
                         help=f"seconds to wait for the cluster to settle (default {HEALTH_TIMEOUT_S})")
+    parser.add_argument("--discord-webhook",
+                        help="Discord webhook URL for the completion notification "
+                             "(falls back to the RENOVATE_DISCORD_WEBHOOK env var)")
+    parser.add_argument("--no-notify", action="store_true",
+                        help="suppress the Discord completion notification")
     args = parser.parse_args()
 
     # Standalone health check — no triage, no merge.
@@ -374,7 +474,7 @@ def main():
 
     if args.merge_safe:
         safe = buckets["safe"]
-        merged_any = False
+        merged = []
         if not safe:
             print("\nNo safe PRs to merge.", file=sys.stderr)
         else:
@@ -386,14 +486,15 @@ def main():
                 print(f"  Reason: {pr['reason']}", file=sys.stderr)
                 ok = run_gh_merge(n, args.repo, args.dry_run)
                 if ok and not args.dry_run:
-                    merged_any = True
+                    merged.append(pr)
                 if not ok:
                     print(f"  WARNING: failed to merge #{n}, continuing", file=sys.stderr)
 
         # Verify the cluster settles before declaring the run complete.
         # Only after a real merge: dry-runs change nothing, and --skip-health-check
         # opts out explicitly.
-        if merged_any and not args.skip_health_check:
+        health = None
+        if merged and not args.skip_health_check:
             print("\nVerifying cluster health after merge...", file=sys.stderr)
             nudge_flux()
             health = verify_cluster_health(timeout_s=args.health_timeout)
@@ -401,12 +502,28 @@ def main():
                   file=sys.stderr)
             if not health["healthy"]:
                 print(json.dumps(health, indent=2), file=sys.stderr)
-                # Non-zero exit so the paired completion-notification step can branch
-                # on success vs. a cluster that didn't settle.
-                sys.exit(1)
-        elif merged_any and args.skip_health_check:
+        elif merged and args.skip_health_check:
             print("\nSkipping cluster health check (--skip-health-check).",
                   file=sys.stderr)
+
+        # Completion notification. Branches success vs. cluster-degraded vs.
+        # nothing-to-merge. Best-effort: a notify failure never fails the run.
+        webhook = args.discord_webhook or os.environ.get("RENOVATE_DISCORD_WEBHOOK")
+        if args.no_notify:
+            pass
+        elif not webhook:
+            print("\nnotify: no Discord webhook configured "
+                  "(--discord-webhook / RENOVATE_DISCORD_WEBHOOK); skipping.",
+                  file=sys.stderr)
+        else:
+            title, color, desc = build_notification(
+                buckets, merged, health, args.skip_health_check)
+            notify_discord(webhook, title, color, desc, dry_run=args.dry_run)
+
+        # Non-zero exit if the cluster didn't settle — after the ⚠️ notification
+        # goes out — so the routine surfaces the failure.
+        if health is not None and not health["healthy"]:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/renovate-triage/triage.py
+++ b/scripts/renovate-triage/triage.py
@@ -260,7 +260,12 @@ def notify_discord(webhook_url, title, color, description, dry_run=False):
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
         webhook_url, data=data,
-        headers={"Content-Type": "application/json"}, method="POST",
+        headers={
+            "Content-Type": "application/json",
+            # Discord rejects requests with the default Python-urllib UA (403).
+            "User-Agent": "home-ops-renovate-triage/1.0 (+https://github.com/1activegeek/home-ops)",
+        },
+        method="POST",
     )
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:


### PR DESCRIPTION
Pairs with the post-merge cluster health check (#299, merged). Adds a completion notification to the weekend Renovate triage routine.

## What
After a real `--merge-safe` run, `triage.py` POSTs a summary embed to a Discord channel webhook:

| State | Color | Headline |
|---|---|---|
| merged + cluster settled | 🟢 green | `✅ merged N PR(s)` |
| merged, health check skipped | 🟠 orange | `✅ merged N PR(s)` |
| cluster did not settle | 🔴 red | `⚠️ cluster did NOT settle` |
| ran, nothing to merge | 🔵 blue | `ℹ️ nothing to merge` |

Body lists merged PRs, majors needing review, waiting-on-CI, and blocked — each with links.

## How
- Webhook URL from `--discord-webhook` or `RENOVATE_DISCORD_WEBHOOK` env. If neither set, notify is skipped and the run is unaffected.
- Best-effort: catches `OSError` (incl. socket timeouts) so a flaky webhook never fails triage.
- The 🔴 degraded notification is sent **before** the non-zero exit, so the routine is still pinged on a cluster failure.
- stdlib `urllib` only — no `requests` dependency (runs in a fresh checkout).
- `--no-notify` suppresses; `--dry-run` prints the payload instead of POSTing.

## Setup still required (out of band)
1. Create a Discord channel webhook → URL.
2. Set `RENOVATE_DISCORD_WEBHOOK` in the triage routine's env (`trig_016nCo7ajYnjcZRG2DTQBEmD`).

## Test
Unit-tested all three `build_notification` branches + graceful failure on unreachable/timeout hosts and dry-run payload. Existing triage/merge/health logic untouched (mechanical `merged_any`→`merged` list; `sys.exit(1)` moved after notify).