### PR TITLE
fix(backup): db-dump jobs failing — Flux ate shell vars (Phase 2 follow-up)

### DIFF
--- a/kubernetes/apps/ai/db-backup/ks.yaml
+++ b/kubernetes/apps/ai/db-backup/ks.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/ai/db-backup/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/home/db-backup/ks.yaml
+++ b/kubernetes/apps/home/db-backup/ks.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/home/db-backup/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/media/db-backup/ks.yaml
+++ b/kubernetes/apps/media/db-backup/ks.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/media/db-backup/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/security/db-backup/ks.yaml
+++ b/kubernetes/apps/security/db-backup/ks.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/security/db-backup/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/tools/db-backup/ks.yaml
+++ b/kubernetes/apps/tools/db-backup/ks.yaml
@@ -6,10 +6,6 @@ metadata:
 spec:
   interval: 1h
   path: ./kubernetes/apps/tools/db-backup/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Follow-up to #308. Verification runs showed pg/mariadb/mongo dump jobs **failing**: `pg_dump` ran with `--file=` (empty) and dumped to stdout.

**Root cause:** the db-backup Kustomizations carried `postBuild.substituteFrom: cluster-secrets`. Flux's `${VAR}` substitution rewrote the dump scripts' shell variables (`${TS}`, `${OUT}`, `${RETENTION_DAYS}`) to empty strings before apply, corrupting every script that used them. The qdrant job (Python heredoc, no shell `${}` tokens) passed — which isolated the cause.

**Fix:** remove `postBuild` from the 5 db-backup ks.yaml. They reference no cluster-secret vars, so it was unneeded; removing it leaves shell `${...}` intact.

Verified locally: `kubectl kustomize` builds clean. Will re-run the per-engine verification jobs after merge+reconcile.

🤖 Authored by Jarvis (agentOS)