### PR TITLE
feat(longhorn): alert on failed backups via apprise→Discord

### DIFF
--- a/kubernetes/apps/longhorn-system/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/kustomization.yaml
@@ -9,3 +9,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./longhorn/ks.yaml
+  - ./longhorn-backup-alert/ks.yaml

--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/cronjob.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/cronjob.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: longhorn-backup-alert
+spec:
+  # Daily at 05:30 UTC — after the 03:00 daily + Sun 04:00 weekly Longhorn
+  # recurring backups complete. Daily cadence keeps a persistent failure to one
+  # alert/day rather than spamming.
+  schedule: "30 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: check
+              image: curlimages/curl:8.11.1
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: METRICS_URL
+                  value: "http://longhorn-backend.longhorn-system:9500/metrics"
+                - name: APPRISE_URL
+                  value: "http://apprise.tools:8000/notify"
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: longhorn-backup-alert-secret
+                      key: DISCORD_WEBHOOK_URL
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  # Longhorn 1.11: longhorn_backup_state value 4 = Error.
+                  # Line shape: longhorn_backup_state{backup="..",volume="..",recurring_job=".."} 4
+                  BODY=$(curl -sf --max-time 20 "${METRICS_URL}")
+                  FAILED=$(printf '%s\n' "${BODY}" | awk '/^longhorn_backup_state\{/ && $NF==4 {print}')
+                  if [ -z "${FAILED}" ]; then
+                    echo "[$(date -u)] OK — no Longhorn backups in Error state."
+                    exit 0
+                  fi
+                  COUNT=$(printf '%s\n' "${FAILED}" | grep -c .)
+                  VOLS=$(printf '%s\n' "${FAILED}" | sed -n 's/.*volume="\([^"]*\)".*/\1/p' | sort -u | tr '\n' ' ')
+                  MSG="Longhorn backup failure: ${COUNT} backup(s) in Error state. Volume(s): ${VOLS}"
+                  echo "[$(date -u)] ${MSG}"
+                  # Convert https://discord.com/api/webhooks/ID/TOKEN -> apprise discord://ID/TOKEN
+                  IDTOK=$(printf '%s' "${DISCORD_WEBHOOK_URL}" | sed -n 's#.*/webhooks/\([0-9][0-9]*\)/\([A-Za-z0-9_-][A-Za-z0-9_-]*\).*#\1/\2#p')
+                  if [ -z "${IDTOK}" ]; then
+                    echo "ERROR: could not parse Discord webhook URL into apprise format" >&2
+                    exit 1
+                  fi
+                  curl -sf --max-time 20 -X POST "${APPRISE_URL}" \
+                    --data-urlencode "urls=discord://${IDTOK}" \
+                    --data-urlencode "title=Longhorn backup failure" \
+                    --data-urlencode "body=${MSG}" >/dev/null
+                  echo "[$(date -u)] Alert dispatched via apprise."
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 64Mi

--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/externalsecret.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: longhorn-backup-alert
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: longhorn-backup-alert-secret
+    template:
+      data:
+        DISCORD_WEBHOOK_URL: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: discord-webhook-jarvis

--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/ks.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: longhorn-backup-alert
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/longhorn-system/longhorn-backup-alert/app
+  # NOTE: intentionally NO postBuild.substituteFrom — the CronJob shell script
+  # uses ${VAR} expansions and Flux var substitution would blank them.
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: longhorn-system
+  wait: false


### PR DESCRIPTION
Adds a daily CronJob in `longhorn-system` that scrapes `longhorn-backend:9500/metrics` for `longhorn_backup_state==4` (Error) and POSTs to apprise (tools ns) → Discord.

**Why a CronJob, not a PrometheusRule:** this cluster runs no Prometheus/Alertmanager (kube-prometheus-stack is CRDs-only), so a PrometheusRule would be inert.

- Discord webhook via ExternalSecret from 1P `discord-webhook-jarvis` (keyed on `webhook_url`).
- `ks.yaml` omits postBuild (CronJob uses `${VAR}`; Flux subst would blank them).
- Hardened pod: non-root, RO rootfs, drop ALL caps, no SA token.
- Daily 05:30 UTC (after the 03:00 daily / Sun 04:00 weekly recurring backups).

**Depends on:** the `webhook_url` value existing in the `discord-webhook-jarvis` item **in the homeops vault** (ESO is scoped to homeops only). First run observed (Bike Method). Please **merge-commit, don't squash** (preserves agent authorship).