### PR TITLE
fix(media): template autoscan password from 1Password (rotate leaked literal)

### DIFF
--- a/kubernetes/apps/media/autoscan/app/externalsecret.yaml
+++ b/kubernetes/apps/media/autoscan/app/externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
 
           authentication:
             username: autoscan
-            password: thisisashittypassword
+            password: "{{ .autoscan_password }}"
 
           port: 3030
 


### PR DESCRIPTION
## What
Replaces the hardcoded `password: thisisashittypassword` literal in `kubernetes/apps/media/autoscan/app/externalsecret.yaml` with `password: "{{ .autoscan_password }}"`, sourced from the 1Password `autoscan` item via the existing `dataFrom.extract.key: autoscan` (same mechanism as `plex_token`).

## Why
The literal was the live credential, committed in plaintext in this public repo (introduced in 85ba14a). autoscan is ClusterIP-only (no external HTTPRoute), so severity is MEDIUM — but the value is public, so the credential has been **rotated** to a fresh 40-char random value in 1Password (field `autoscan_password`, vault `homeops`) as part of this change.

## Validation
- ✅ `task validate:secrets` → `autoscan (item: autoscan): all 2 field(s) matched` (autoscan_password + plex_token).
- ✅ `kubectl kustomize` builds clean.
- flux-local rendered/static gates: CI on this PR (not installed locally).

## ⚠️ Before merge — verify the callers
autoscan's `authentication` block is the credential that **Sonarr/Radarr present when calling autoscan**. If Sonarr/Radarr have a Connect/webhook configured to autoscan with the *old* password, rotating it will break that trigger until their autoscan connection setting is updated to the new value (in 1P `autoscan.autoscan_password`). Confirm or update those before/after merge. ESO+Reloader auto-restart autoscan within ~1m of merge.

## Plan
`1 Projects/Home-Ops Security Hardening (home-ops)/plans/02-autoscan-secret-rotation.md`

🤖 Staged by Jarvis (agentOS) — autonomous PICKUP