### PR TITLE
security(mqtt): require auth on mosquitto, add per-client creds [DO NOT MERGE until UI steps done]

### DIFF
--- a/kubernetes/apps/home/mosquitto/app/externalsecret.yaml
+++ b/kubernetes/apps/home/mosquitto/app/externalsecret.yaml
@@ -2,19 +2,16 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: teslamate
+  name: mosquitto
 spec:
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-store
   target:
-    name: teslamate-secret
-  dataFrom:
-    - extract:
-        key: teslamate
+    name: mosquitto-secret
   data:
-    - secretKey: mqtt_password
+    - secretKey: mosquitto_pwd
       remoteRef:
-        key: teslamate
-        property: mqtt_password
+        key: mosquitto
+        property: mosquitto_pwd

--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -11,6 +11,8 @@ spec:
   values:
     controllers:
       mosquitto:
+        annotations:
+          reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
@@ -48,6 +50,13 @@ spec:
         globalMounts:
           - path: /mosquitto/config/mosquitto.conf
             subPath: mosquitto.conf
+      secret-file:
+        type: secret
+        name: mosquitto-secret
+        globalMounts:
+          - path: /mosquitto/external_config/mosquitto_pwd
+            subPath: mosquitto_pwd
+            readOnly: true
       data:
         type: persistentVolumeClaim
         storageClass: longhorn
@@ -61,6 +70,7 @@ spec:
         data:
           mosquitto.conf: |
             listener 1883
-            allow_anonymous true
+            allow_anonymous false
+            password_file /mosquitto/external_config/mosquitto_pwd
             persistence true
             persistence_location /mosquitto/data/

--- a/kubernetes/apps/home/mosquitto/app/kustomization.yaml
+++ b/kubernetes/apps/home/mosquitto/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/home/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/home/teslamate/app/helmrelease.yaml
@@ -35,6 +35,12 @@ spec:
                     key: encryption_key
               MQTT_HOST: mosquitto.home.svc.cluster.local
               MQTT_PORT: "1883"
+              MQTT_USERNAME: teslamate
+              MQTT_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: teslamate-secret
+                    key: mqtt_password
               TZ: America/Denver
             probes:
               liveness: &probes


### PR DESCRIPTION
## ⚠️ DRAFT — DO NOT MERGE until the 3 client UIs are reconfigured (see below)
Merging flips `allow_anonymous false` on the broker. Any MQTT client that hasn't yet been given its new credentials **loses connectivity at merge time** — Home Assistant entities go unavailable, Z-Wave state goes stale, music-assistant loses HA control, and teslamate GPS history gaps. Sequence: creds + clients FIRST, merge LAST.

## What
Eliminates anonymous access to `mosquitto.home.svc.cluster.local:1883` (today any pod can wildcard-subscribe live `teslamate/*` GPS and forge HA/Z-Wave state).
- **mosquitto** (`helmrelease.yaml`): `allow_anonymous false` + `password_file` on a read-only secret mount under `/mosquitto/external_config/` (RO-rootfs safe), Reloader annotation.
- **new** `externalsecret.yaml`: pulls the hashed `mosquitto_pwd` password_file from 1P item `mosquitto`.
- **kustomization.yaml**: adds the externalsecret.
- **teslamate** (`helmrelease.yaml` + `externalsecret.yaml`): `MQTT_USERNAME=teslamate` + `MQTT_PASSWORD` from `teslamate-secret.mqtt_password`.

## Credentials — ALREADY generated & in 1Password (vault `homeops`)
- Item `mosquitto`: `mosquitto_pwd` = 4-user hashed password_file (teslamate, homeassistant, zwavejsui, musicassistant); plus `ha_password` / `zw_password` / `ma_password` (plaintext, for the UI steps below).
- Item `teslamate`: `mqtt_password` rotated to match the hashed file.

## Before merge — reconfigure the 3 PVC/UI-based clients (not manifest-controlled)
While the broker is still anonymous, set MQTT user/pass in each UI (read passwords from 1P `mosquitto`):
1. **Home Assistant** → Settings → Devices & Services → MQTT → Configure → user `homeassistant`, pw = `ha_password`.
2. **zwave-js-ui** → Settings → MQTT → user `zwavejsui`, pw = `zw_password`.
3. **music-assistant** → Settings → MQTT/HA provider → user `musicassistant`, pw = `ma_password`.
Then merge. Reloader restarts mosquitto (new secret mount) + teslamate (new env). Validate per plan (anonymous CONNECT → `not authorised`; authed clients streaming).

## Validation so far
- ✅ 1P fields verified present (mosquitto_pwd = 4 lines; teslamate.mqtt_password set).
- ✅ `kubectl kustomize` builds clean for both apps.
- flux-local `validate:flux` / `validate:secret-keys` → CI on this PR.

## Plan
`1 Projects/Home-Ops Security Hardening (home-ops)/plans/03-mosquitto-auth-lockdown.md`

🤖 Staged by Jarvis (agentOS) — autonomous PICKUP