### PR TITLE
chore(images): pin HelmRelease image tags off `latest`

### DIFF
--- a/kubernetes/apps/ai/librechat/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/librechat/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: ghcr.io/danny-avila/librechat
-              tag: latest
+              tag: v0.8.6
             env:
               HOST: "0.0.0.0"
               PORT: "3080"

--- a/kubernetes/apps/ai/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/n8n/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: docker.n8n.io/n8nio/n8n
-              tag: latest
+              tag: 2.26.4
             env:
               DB_TYPE: postgresdb
               DB_POSTGRESDB_HOST: n8n-postgres

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
           app:
             image:
               repository: ghcr.io/advplyr/audiobookshelf
-              tag: latest
+              tag: 2.35.1
             env:
               TZ: America/New_York
             probes:

--- a/kubernetes/apps/media/autoscan/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autoscan/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/hotio/autoscan
-              tag: latest
+              tag: release-b2f4c22
             env:
               TZ: America/New_York
               PUID: "1000"

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -17,12 +17,10 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/hotio/bazarr
-              tag: release-2665a5c
+              repository: ghcr.io/home-operations/bazarr
+              tag: 1.5.6
             env:
               TZ: America/New_York
-              PUID: "1027"
-              PGID: "100"
             probes:
               liveness: &probes
                 enabled: true
@@ -37,13 +35,21 @@ spec:
                   failureThreshold: 3
               readiness: *probes
             securityContext:
+              allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 50m
                 memory: 256Mi
               limits:
                 memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1027
+        runAsGroup: 100
+        fsGroup: 100
     service:
       app:
         controller: bazarr

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/hotio/bazarr
-              tag: latest
+              tag: release-2665a5c
             env:
               TZ: America/New_York
               PUID: "1027"

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/seerr-team/seerr
-              tag: latest
+              tag: v3.3.0
             env:
               TZ: America/New_York
               LOG_LEVEL: info

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/tautulli/tautulli
-              tag: latest
+              tag: v2.17.2
             env:
               TZ: America/New_York
             envFrom:

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/unpackerr/unpackerr
-              tag: latest
+              tag: v0.15.2
             env:
               TZ: America/New_York
               UN_SONARR_0_URL: http://sonarr.media.svc.cluster.local:8989

--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
           app:
             image:
               repository: ghcr.io/headlamp-k8s/headlamp
-              tag: latest
+              tag: v0.43.0
             args:
               - -in-cluster
               - -plugins-dir

--- a/kubernetes/apps/tools/apprise/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/apprise/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
           app:
             image:
               repository: linuxserver/apprise-api
-              tag: latest
+              tag: 1.5.0
             env:
               TZ: America/New_York
               PUID: "1027"

--- a/kubernetes/apps/tools/code-server/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/code-server/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
           app:
             image:
               repository: ghcr.io/coder/code-server
-              tag: latest
+              tag: 4.124.2
             args:
               - --auth
               - none

--- a/kubernetes/apps/tools/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/homepage/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
           app:
             image:
               repository: ghcr.io/gethomepage/homepage
-              tag: latest
+              tag: v1.13.2
             env:
               TZ: America/New_York
               HOMEPAGE_ALLOWED_HOSTS: "home.${SECRET_DOMAIN}"

--- a/kubernetes/apps/tools/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/nextcloud/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: nextcloud
-              tag: latest
+              tag: 33.0.1
             env:
               POSTGRES_HOST: nextcloud-postgres
               POSTGRES_DB: nextcloud
@@ -133,7 +133,7 @@ spec:
           cron:
             image:
               repository: curlimages/curl
-              tag: latest
+              tag: 8.20.0
             command:
               - curl
               - -s


### PR DESCRIPTION
## Why
13 HelmReleases pinned their container image to `tag: latest`. A floating `latest` is **invisible to Renovate** — it can't tell us when a new version ships, and the running pods had silently drifted behind. This pins every one to an explicit version so Renovate can track and propose updates.

## What `latest` resolved to (registry digest match) vs. what's running
All running pods were behind current `latest` except unpackerr.

| App | was | pinned to | note |
|---|---|---|---|
| librechat | latest | `v0.8.6` | current latest |
| n8n | latest | `2.26.4` | current latest (running 2.13.4 → same-major) |
| audiobookshelf | latest | `2.35.1` | current latest |
| seerr | latest | `v3.3.0` | current latest |
| tautulli | latest | `v2.17.2` | current latest (`latest` is a separate rolling build) |
| unpackerr | latest | `v0.15.2` | already current |
| headlamp | latest | `v0.43.0` | current latest |
| apprise-api | latest | `1.5.0` | current latest |
| code-server | latest | `4.124.2` | current latest |
| homepage | latest | `v1.13.2` | current latest |
| nextcloud | latest | `33.0.1` | **running version, NOT latest** — `latest` is 34.0.0, a major jump. Pinned to running so the 33→34 upgrade comes through Renovate as a deliberate, reviewable PR. |
| curl (nextcloud sidecar) | latest | `8.20.0` | current latest |
| **bazarr** | latest (→ hotio sha) | **`ghcr.io/home-operations/bazarr:1.5.6`** | **migrated off hotio** to the home-operations image (matches radarr/sonarr/prowlarr) for a clean semver Renovate datasource. Runs as 1027:100 via `defaultPodOptions` (preserves existing /config PVC ownership); hotio PUID/PGID env dropped. |
| autoscan | latest | `ghcr.io/hotio/autoscan:release-b2f4c22` | **kept on hotio** — see below |

## autoscan: no good semver alternative
- home-operations has **no** autoscan image.
- The only semver-tagged option, `cloudb0x/autoscan`, was last pushed **2021-02** (5 yrs, abandoned).
- autoscan upstream is **archived** — no image will ever ship new versions, so Renovate visibility is moot.
- → Kept on the maintained hotio `release-<sha>` immutable pin (gets base-image rebuilds; at least no longer floating `latest`).

## Notes / follow-ups
- **nextcloud**: deliberately left on its running major (33). Renovate will surface 34 separately — do that one on purpose (DB migration, app compat).
- **n8n**: same major but 13 minors behind (2.13 → 2.26); upgrade is in-scope but watch workflow compat on reconcile.
- **Heads-up (out of scope):** radarr/sonarr/prowlarr use `tag: rolling`, which this repo's Renovate config does **not** track (no home-operations preset / no digests) — those float like `latest` did. Worth pinning to semver later if you want Renovate visibility on them too.

Verified: no app uses `latest`; all changed YAML parses; versions resolved by matching each registry's `latest` manifest digest against version tags; bazarr UID/GID preserved against the existing PVC.

🤖 Pinned & migrated by Jarvis (agentOS)