### PR TITLE
chore(images): pin *arr image tags off `rolling` to semver

### DIFF
--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/prowlarr
-              tag: rolling
+              tag: 2.4.0.5397
             env:
               TZ: America/New_York
               PROWLARR__APP__INSTANCENAME: Prowlarr

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/radarr
-              tag: rolling
+              tag: 6.2.1.10461
             env:
               TZ: America/New_York
               RADARR__APP__INSTANCENAME: Radarr

--- a/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr4k/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/radarr
-              tag: rolling
+              tag: 6.2.1.10461
             env:
               TZ: America/New_York
               RADARR__APP__INSTANCENAME: Radarr 4K

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/sonarr
-              tag: rolling
+              tag: 4.0.17.2969
             env:
               TZ: America/New_York
               SONARR__APP__INSTANCENAME: Sonarr


### PR DESCRIPTION
## Why
radarr, radarr4k, sonarr, and prowlarr run home-operations images on `tag: rolling`. `rolling` is a **floating** tag — and this repo's Renovate config has no home-operations preset and pins no digests, so Renovate never tracks it (same blind spot as the `latest` tags fixed in #319). This pins each to the version `rolling` resolves to **today**, so Renovate can detect and propose updates going forward.

Because `rolling` always means "newest," pinning to current-newest is consistent with their existing behavior — it just freezes the floating pointer so updates become reviewable PRs.

| App | image | was | pinned to |
|---|---|---|---|
| radarr | ghcr.io/home-operations/radarr | `rolling` | `6.2.1.10461` |
| radarr4k | ghcr.io/home-operations/radarr | `rolling` | `6.2.1.10461` |
| sonarr | ghcr.io/home-operations/sonarr | `rolling` | `4.0.17.2969` |
| prowlarr | ghcr.io/home-operations/prowlarr | `rolling` | `2.4.0.5397` |

Versions resolved by matching each image's `rolling` manifest digest against its semver tags (all matched the newest semver). No other changes — these already run the home-operations nonroot pattern.

## Relationship to #319
Sibling to #319 (which pins the `latest` tags + migrates bazarr → home-operations). Split out per request so the *arr semver pins land independently.

🤖 Pinned by Jarvis (agentOS)