### PR TITLE
fix(agentbox): fetch ts_authkey by property, not dataFrom.extract

### DIFF
--- a/kubernetes/apps/ai/agentbox/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/agentbox/app/externalsecret.yaml
@@ -15,9 +15,13 @@ spec:
     name: onepassword-store
   target:
     name: agentbox-secret
-    template:
-      data:
-        ts_authkey: "{{ .ts_authkey }}"
-  dataFrom:
-    - extract:
+  # Fetch the ts_authkey field explicitly (not dataFrom.extract): the 1Password
+  # item has a notes/field collision that makes extract fail with
+  # "expected one ItemField matching 'notesPlain', got 2". Pulling the named
+  # field by property sidesteps the whole-item scan. Matches the mosquitto
+  # ExternalSecret pattern.
+  data:
+    - secretKey: ts_authkey
+      remoteRef:
         key: agentbox
+        property: ts_authkey


### PR DESCRIPTION
## Problem

After #332 merged, the `agentbox` pod is stuck in `CreateContainerConfigError` — `secret "agentbox-secret" not found`. Root cause is the ExternalSecret failing to sync:

```
error processing spec.dataFrom[0].extract, err: expected one 1Password ItemField matching: 'notesPlain' in 'agentbox', got 2
```

`dataFrom.extract` scans the whole 1Password item and trips on a notes/field collision (two fields map to `notesPlain`), so `agentbox-secret` is never created and the `TS_AUTHKEY` `secretKeyRef` can't resolve.

## Fix

Switch from `dataFrom.extract` to an explicit `data` + `remoteRef.property: ts_authkey` mapping that pulls only the named field, sidestepping the whole-item scan. Matches the existing `mosquitto` ExternalSecret pattern in this repo.

- Renders clean via `kustomize build kubernetes/apps/ai/agentbox/app`.
- No change to the produced secret shape: still `agentbox-secret` with key `ts_authkey`, exactly what the HelmRelease `secretKeyRef` expects.

## Verify after merge

```
kubectl -n ai get externalsecret agentbox   # STATUS = SecretSynced
kubectl -n ai get pods -l app.kubernetes.io/name=agentbox   # Running
```

If the secret still errors, the 1P `agentbox` item's field isn't labeled `ts_authkey` — that's the one residual unknown (couldn't verify the item structure during the autonomous run).

> Do not squash-merge (preserves authorship).

https://claude.ai/code/session_015N5QyeQbF2rq65YR7suv9m