### PR TITLE
fix(agentbox): escape TS_* shell vars from Flux postBuild substitution

### DIFF
--- a/kubernetes/apps/ai/agentbox/app/configmap.yaml
+++ b/kubernetes/apps/ai/agentbox/app/configmap.yaml
@@ -46,7 +46,11 @@ data:
       || log "WARN cli install/update had issues (will retry next boot)"
 
     # 4. Tailscale up with SSH (userspace mode -> no NET_ADMIN / tun) -------
-    if [ -x "$BIN/tailscaled" ] && [ -n "${TS_AUTHKEY:-}" ]; then
+    # NOTE: TS_* runtime vars are written $${...} so Flux's postBuild
+    # substituteFrom (cluster-secrets) does NOT rewrite them to empty strings.
+    # Flux renders $${VAR} -> ${VAR}, leaving the runtime shell to expand it.
+    # Bare $HOME/$BIN survive substitution; only brace-form ${VAR} is eaten.
+    if [ -x "$BIN/tailscaled" ] && [ -n "$${TS_AUTHKEY:-}" ]; then
       log "starting tailscaled (userspace) + tailscale up --ssh"
       "$BIN/tailscaled" \
         --tun=userspace-networking \
@@ -55,8 +59,8 @@ data:
         >"$HOME/.tailscale/tailscaled.log" 2>&1 &
       sleep 3
       "$BIN/tailscale" --socket="$HOME/.tailscale/tailscaled.sock" up \
-        --authkey="${TS_AUTHKEY}" \
-        --hostname="${TS_HOSTNAME:-agentbox}" \
+        --authkey="$${TS_AUTHKEY}" \
+        --hostname="$${TS_HOSTNAME:-agentbox}" \
         --ssh \
         --accept-routes \
         || log "WARN tailscale up failed"


### PR DESCRIPTION
## Problem

After the ESO fix (#333), the pod reached `Running` but **never joined the tailnet** — `ssh pwuser@agentbox` doesn't work. Boot log:

```
WARN skipping tailscale (no binary or no TS_AUTHKEY)
```

…despite the `agentbox-secret` syncing and the tailscale binary being present + executable on the PVC.

## Root cause

The deployed ConfigMap rendered with **empty** TS vars:

```bash
if [ -x "$BIN/tailscaled" ] && [ -n "" ]; then   # ${TS_AUTHKEY:-} → ""
  --authkey=""                                    # ${TS_AUTHKEY}   → ""
```

The Kustomization's `postBuild.substituteFrom` (cluster-secrets) runs envsubst over the ConfigMap and rewrites **brace-form** `${TS_AUTHKEY}` / `${TS_HOSTNAME}` to empty strings (they aren't cluster-secrets). Bare `$HOME`/`$BIN` survive — only `${VAR}` is eaten. CI/kustomize build pass because substitution happens at Flux apply time.

## Fix

Write the three `TS_*` runtime refs as `$${...}` so Flux renders them back to `${...}` for the runtime shell instead of substituting. These are the only brace-form vars in the script.

## Verified live

Manually ran the step-4 block inside the running pod with the real env → it joined the tailnet (`agentbox.taile319.ts.net`, `--ssh` up). Confirms the authkey / binary / userspace path is sound and the empty-var substitution was the sole failure.

## After merge

ConfigMap change → restart the pod once so the fixed entrypoint runs; tailscale then auto-joins on every boot:
```
kubectl -n ai rollout restart deploy/agentbox
kubectl -n ai logs deploy/agentbox | grep -i tailscale
```

> Do not squash-merge (preserves authorship).

https://claude.ai/code/session_015N5QyeQbF2rq65YR7suv9m