### PR TITLE
feat(agentbox): persist PATH for interactive SSH login shells

### DIFF
--- a/kubernetes/apps/ai/agentbox/app/configmap.yaml
+++ b/kubernetes/apps/ai/agentbox/app/configmap.yaml
@@ -45,6 +45,20 @@ data:
     npm install -g @anthropic-ai/claude-code @openai/codex >/dev/null 2>&1 \
       || log "WARN cli install/update had issues (will retry next boot)"
 
+    # 3b. Persist PATH for interactive SSH login shells ---------------------
+    #    Tools live on the PVC under ~/.local/bin and ~/.npm-global/bin. The
+    #    entrypoint's PATH only covers its own process tree (incl. the zellij
+    #    session it launches), so a bare `ssh pwuser@agentbox` login shell
+    #    wouldn't find claude/codex/zellij. Write login + interactive rc files
+    #    so it does. $HOME is bare (Flux only rewrites brace-form ${VAR}).
+    log "writing shell rc files (PATH for SSH logins)"
+    cat > "$HOME/.bashrc" <<'BRC'
+    export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"
+    BRC
+    cat > "$HOME/.bash_profile" <<'BP'
+    [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"
+    BP
+
     # 4. Tailscale up with SSH (userspace mode -> no NET_ADMIN / tun) -------
     # NOTE: TS_* runtime vars are written $${...} so Flux's postBuild
     # substituteFrom (cluster-secrets) does NOT rewrite them to empty strings.


### PR DESCRIPTION
## Problem

Tools install onto the PVC (`~/.local/bin`, `~/.npm-global/bin`), but the entrypoint's `PATH` only covers its own process tree. A bare `ssh pwuser@agentbox` login shell gets the container's default PATH and can't find `claude`/`codex`/`zellij`. (The runbook's attach-zellij flow works because that session inherits the entrypoint's PATH — this fixes the shells outside it.)

## Fix

On each boot, write:
- `~/.bashrc` → `export PATH="$HOME/.local/bin:$HOME/.npm-global/bin:$PATH"`
- `~/.bash_profile` → sources `~/.bashrc` (bash login shells read this)

`$HOME` left bare so Flux `postBuild` substitution doesn't touch it. Rendered entrypoint passes `bash -n`.

## Verify after merge

```
kubectl -n ai rollout restart deploy/agentbox
ssh pwuser@agentbox 'which claude codex zellij'   # all resolve
```

> Do not squash-merge (preserves authorship).

https://claude.ai/code/session_015N5QyeQbF2rq65YR7suv9m