### PR TITLE
fix(agentbox): zellij PTY-at-boot + auto-attach on SSH login

### DIFF
--- a/kubernetes/apps/ai/agentbox/app/configmap.yaml
+++ b/kubernetes/apps/ai/agentbox/app/configmap.yaml
@@ -57,6 +57,12 @@ data:
     BRC
     cat > "$HOME/.bash_profile" <<'BP'
     [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"
+    # Auto-attach to the persistent agentbox session on interactive SSH login.
+    # $${ZELLIJ} is escaped so Flux postBuild leaves it for the runtime shell;
+    # guard skips when already inside zellij (panes) or non-interactive (scp).
+    case $- in
+      *i*) [ -z "$${ZELLIJ:-}" ] && command -v zellij >/dev/null && zellij attach -c agentbox || true ;;
+    esac
     BP
 
     # 4. Tailscale up with SSH (userspace mode -> no NET_ADMIN / tun) -------
@@ -92,8 +98,13 @@ data:
     KDL
     if [ -x "$BIN/zellij" ]; then
       log "starting persistent zellij session 'agentbox'"
-      setsid bash -c "$BIN/zellij --layout $HOME/.config/zellij/layouts/agent.kdl attach --create agentbox" \
-        </dev/null >"$HOME/.zellij-boot.log" 2>&1 &
+      # zellij needs a controlling PTY to enter raw mode; a plain
+      # `setsid bash -c` gives it none (panics "could not enable raw mode").
+      # `script` allocates a pseudo-TTY headlessly so the boot session — and
+      # the auto-respawn claude inside it — actually start (always-on relay).
+      setsid script -qfc \
+        "$BIN/zellij --layout $HOME/.config/zellij/layouts/agent.kdl attach --create agentbox" \
+        "$HOME/.zellij-boot.log" </dev/null >/dev/null 2>&1 &
     fi
 
     log "boot complete; holding PID 1"


### PR DESCRIPTION
## Problems

1. **Always-on session never started.** Boot log: `zellij panicked: could not enable raw mode: ... No such device or address`. `setsid bash -c "zellij … attach --create"` gives zellij no controlling PTY. So the persistent session and its auto-respawn `claude` (what the phone relay shows) never came up.
2. **No auto-attach.** `ssh pwuser@agentbox` dropped into a plain shell instead of the session.

## Fixes

1. Launch zellij under `script -qfc … "$HOME/.zellij-boot.log"` — `script` allocates a pseudo-TTY headlessly so zellij can enter raw mode. **Verified live in-pod**: session starts, no panic, `claude` runs inside it.
2. `~/.bash_profile` now auto-attaches: `case $- in *i*) [ -z "${ZELLIJ:-}" ] && zellij attach -c agentbox` — interactive-only (skips scp), and skips when already inside a pane. `$$`-escaped against Flux postBuild (same pattern as the TS_* fix).

## After merge
```
kubectl -n ai rollout restart deploy/agentbox
kubectl -n ai logs deploy/agentbox | grep -i zellij   # no panic
ssh pwuser@agentbox   # lands directly in the agentbox session
```

> Do not squash-merge (preserves authorship).

https://claude.ai/code/session_015N5QyeQbF2rq65YR7suv9m