### PR TITLE
fix(agentbox): clear stale zellij session before boot launch

### DIFF
--- a/kubernetes/apps/ai/agentbox/app/configmap.yaml
+++ b/kubernetes/apps/ai/agentbox/app/configmap.yaml
@@ -153,6 +153,11 @@ data:
     KDL
     if [ -x "$BIN/zellij" ]; then
       log "starting persistent zellij session 'agentbox'"
+      # zellij persists session metadata on the PVC (~/.cache/zellij), so a
+      # session named 'agentbox' survives pod restarts as a dead/resurrectable
+      # entry that blocks creation ("already exists, but is dead"). Clear it
+      # first so every boot starts a clean session with the agent layout.
+      "$BIN/zellij" delete-session agentbox --force >/dev/null 2>&1 || true
       # zellij needs a controlling PTY to enter raw mode; a plain
       # `setsid bash -c` gives it none (panics "could not enable raw mode").
       # `script` allocates a pseudo-TTY headlessly so the boot session — and


### PR DESCRIPTION
Follow-up to #337, caught in live post-deploy verification.

**Bug:** zellij persists session metadata on the PVC (`~/.cache/zellij`), so the `agentbox` session survives a pod restart as a dead/resurrectable entry. The new `--new-session-with-layout` launch then fails with *"Session with name 'agentbox' already exists, but is dead"* and the claude respawn loop never starts. (The previous `attach --create` form masked this by resurrecting the dead session — into a bare `sh`, not the agent layout.)

**Fix:** `zellij delete-session agentbox --force` immediately before the boot launch, so every restart starts a clean session with `agent.kdl`.

**Verified live:** in the running pod, `delete-session agentbox --force` then `--new-session-with-layout` → respawn loop running, claude process count = 1.

Build OK · `bash -n` OK (pre/post-Flux) · yamllint clean.

🤖 Do not squash-merge.

https://claude.ai/code/session_015N5QyeQbF2rq65YR7suv9m