### PR TITLE
feat(forgejo): end postgres drift + application-consistent SQLite backup

### DIFF
--- a/kubernetes/apps/tools/db-backup/app/cronjob-forgejo.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-forgejo.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-forgejo
+spec:
+  schedule: "40 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: db-backup-forgejo
+          automountServiceAccountToken: true
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: docker.io/alpine/k8s:1.34.1
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: HOME
+                  value: /tmp
+                - name: RETENTION_DAYS
+                  value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/forgejo-${TS}.tar.gz"
+                  # Forgejo's SQLite DB lives on an RWO Longhorn PVC mounted only
+                  # by the running pod, so the consistent dump is taken by execing
+                  # forgejo's native `dump` inside that pod and streaming it out.
+                  POD=$(kubectl get pod -n tools -l app.kubernetes.io/name=forgejo \
+                    --field-selector status.phase=Running \
+                    -o jsonpath='{.items[0].metadata.name}')
+                  echo "[$(date -u)] forgejo dump ${POD} -> ${OUT}"
+                  # Logical dump = DB + config + attachments + packages. Git repos
+                  # and LFS are skipped; their bulk data is on the block-backed PVC.
+                  kubectl exec -n tools "${POD}" -c forgejo -- \
+                    forgejo dump --type tar.gz --quiet \
+                      --skip-repository --skip-lfs-data --skip-repo-archives \
+                      --file - > "${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning forgejo-*.tar.gz older than ${RETENTION_DAYS}d"
+                  find /backups -name 'forgejo-*.tar.gz' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/tools/db-backup/app/kustomization.yaml
@@ -3,7 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./pvc.yaml
+  - ./rbac.yaml
   - ./cronjob-atuin.yaml
+  - ./cronjob-forgejo.yaml
   - ./cronjob-nextcloud.yaml
   - ./cronjob-shlink.yaml
   - ./cronjob-zipline.yaml

--- a/kubernetes/apps/tools/db-backup/app/rbac.yaml
+++ b/kubernetes/apps/tools/db-backup/app/rbac.yaml
@@ -1,0 +1,40 @@
+---
+# Least-privilege identity for the forgejo SQLite backup CronJob.
+# Forgejo stores its DB in an embedded SQLite file on an RWO Longhorn PVC that
+# is exclusively mounted by the running forgejo pod, so the dump cannot be taken
+# by mounting the volume from a second pod. Instead the job execs `forgejo dump`
+# inside the live pod (application-consistent), which needs get/list on pods and
+# create on pods/exec — scoped to the tools namespace only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db-backup-forgejo
+  namespace: tools
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: db-backup-forgejo
+  namespace: tools
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: db-backup-forgejo
+  namespace: tools
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: db-backup-forgejo
+subjects:
+  - kind: ServiceAccount
+    name: db-backup-forgejo
+    namespace: tools

--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -1,5 +1,5 @@
 ---
-# Admin credentials and database password for Forgejo
+# Admin credentials for Forgejo
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -17,8 +17,6 @@ spec:
         username: "{{ .admin_username }}"
         # Admin password (chart expects key "password")
         password: "{{ .admin_password }}"
-        # PostgreSQL credentials
-        db-password: "{{ .db_password }}"
   dataFrom:
     - extract:
         key: forgejo

--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -83,30 +83,15 @@ spec:
         # Provider: OpenID Connect
         # Discovery URL: https://authentik.${SECRET_DOMAIN}/application/o/forgejo/.well-known/openid-configuration
 
-    # PostgreSQL subchart (Bitnami)
-    postgresql:
-      enabled: true
-      global:
-        postgresql:
-          auth:
-            existingSecret: forgejo-secret
-            secretKeys:
-              adminPasswordKey: db-password
-              userPasswordKey: db-password
-            database: forgejo
-            username: forgejo
-      primary:
-        persistence:
-          enabled: true
-          storageClass: longhorn
-          size: 5Gi
+    # Forgejo runs on its embedded SQLite database (DB_TYPE=sqlite3), which is
+    # appropriate for this single-user homelab instance. The forgejo-helm chart
+    # bundles no PostgreSQL subchart, so the previously-declared postgresql /
+    # postgresql-ha value blocks were inert (silently ignored) and never
+    # provisioned a database. Removed to end manifest-vs-reality drift.
+    # Application-consistent DB backups: see db-backup/app/cronjob-forgejo.yaml.
 
     # Disable Redis cluster (use memory for single-pod)
     redis-cluster:
-      enabled: false
-
-    # Disable HA PostgreSQL
-    postgresql-ha:
       enabled: false
 
     strategy:


### PR DESCRIPTION
## Summary
Resolves the Forgejo "postgres discrepancy": the HelmRelease declared a PostgreSQL database that was never created. Forgejo has run on its **embedded SQLite DB** since day one (125 days). This is **Option A** from the investigation (Shawn-approved): de-drift the manifest and add an application-consistent backup.

## Root cause
`forgejo-helm` 17.1.0 bundles **no** `postgresql` subchart (only `common`). The `postgresql:` / `postgresql-ha:` value blocks were **unknown keys Helm silently ignored** — pure manifest-vs-reality drift, never a running database. Verified via `helm show values`/`helm show chart` and a live `helm template` render (no postgres resources produced before or after).

## Changes
**De-drift** (`kubernetes/apps/tools/forgejo/app/`)
- `helmrelease.yaml` — remove the inert `postgresql:` and `postgresql-ha:` value blocks (`redis-cluster: false` left untouched — out of scope).
- `externalsecret.yaml` — drop the now-unused `db-password` projection (only the removed postgres block consumed it). The `db_password` field is **left in the 1Password `forgejo` item**, just no longer surfaced into the Secret.

**Application-consistent backup** (`kubernetes/apps/tools/db-backup/app/`)
- `cronjob-forgejo.yaml` — new `db-backup-forgejo` CronJob, **02:40 daily, 14-day retention**, writing to the existing `db-backups` PVC (already off-boxed by the 03:00 Longhorn backup). Mirrors the sibling `cronjob-atuin.yaml` structure/retention/security context.
- `rbac.yaml` — least-privilege `ServiceAccount` + `Role` (`get,list` pods; `create` pods/exec) + `RoleBinding`, scoped to the `tools` namespace.
- `kustomization.yaml` — register `rbac.yaml` + `cronjob-forgejo.yaml`.

## Why exec instead of a plain dump container
Forgejo's SQLite file lives on an **RWO Longhorn PVC mounted only by the running pod**, and it runs in WAL mode with live writes — so it can't be dumped by mounting the volume from a second pod (RWO conflict; WAL needs write access). The backup instead execs Forgejo's **native `forgejo dump`** inside the live pod (the SQLite equivalent of `pg_dump` reaching postgres over TCP) and streams the archive out. Dump scope: DB + config + attachments + packages; **repos and LFS skipped** (their bulk data is already covered by Longhorn block backup). Image `docker.io/alpine/k8s:1.34.1` (matches cluster v1.34.1; includes a shell for timestamp/prune).

> Note: the `db-backup` Flux Kustomization has **no** `postBuild.substituteFrom`, so the script's `${VAR}` refs are bare (matching the sibling atuin job) — no `$${}` escaping needed here.

## Validation
- `yamllint -c .yamllint.yaml` — PASS on all 5 files
- `kubectl kustomize .../db-backup/app` — renders 9 resources
- `kubeconform` — db-backup app **9/9 valid**; forgejo externalsecret **2/2 valid**
- `helm template` with the edited values — **8 resources render, zero postgres** (confirms the removed blocks were inert)

## Deploy note
Do **not** merge until reviewed — merge auto-deploys via Flux (`prune: true`).

https://claude.ai/code/session_01PVdaTHNxbRVpyvekq5XvCA
