### PR TITLE
feat(hermes-agent): revive Hermes Agent in ai namespace (bootstrap)

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-dotenv
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: hermes-dotenv
+    template:
+      engineVersion: v2
+      data:
+        # Only the API server key is provisioned via secret. The OpenAI/ChatGPT
+        # provider credential is obtained interactively via the Codex OAuth
+        # device flow (`hermes setup`) and persists in auth.json on the PVC, not
+        # here. Telegram/Home Assistant creds are deferred — add fields to the
+        # hermes-dotenv 1Password item and reference them here when enabling.
+        .env: |
+          API_SERVER_KEY={{ .API_SERVER_KEY }}
+  data:
+    - secretKey: API_SERVER_KEY
+      remoteRef:
+        key: hermes-dotenv
+        property: password

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes-agent
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hermes-agent
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsUser: 10000
+            runAsGroup: 10000
+            fsGroup: 10000
+        containers:
+          gateway:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.16
+            # BOOTSTRAP: entrypoint detects `sleep` as an executable and passes
+            # it through, activating the venv and scaffolding /opt/data before
+            # sleeping. Exec in to run `hermes setup` (OpenAI Codex OAuth device
+            # flow), then flip args to: ["gateway", "run"]
+            args: ["sleep", "infinity"]
+            env:
+              HERMES_HOME: /opt/data
+              PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
+              PYTHONUNBUFFERED: "1"
+              API_SERVER_ENABLED: "true"
+              API_SERVER_HOST: "0.0.0.0"
+              API_SERVER_PORT: "8642"
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 3Gi
+          dashboard:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.16
+            # BOOTSTRAP: same pattern — entrypoint runs, venv activated, then
+            # sleeps. After `hermes setup`, flip args to:
+            # ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
+            # and re-add the HTTP liveness/readiness probes (GET / :9119).
+            args: ["sleep", "infinity"]
+            env:
+              HERMES_HOME: /opt/data
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 9119
+          api:
+            port: 8642
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        globalMounts:
+          - path: /opt/data
+      shared:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/hermes"
+        globalMounts:
+          - path: /opt/data/shared
+
+      hermes-dotenv:
+        type: secret
+        name: hermes-dotenv
+        globalMounts:
+          - path: /opt/data/.env
+            subPath: .env
+            readOnly: true
+
+    route:
+      app:
+        hostnames: ["hermes.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: hermes-agent
+                port: 9119

--- a/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret-dotenv.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/hermes-agent/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes-agent
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes-agent/ks.yaml
+++ b/kubernetes/apps/ai/hermes-agent/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: hermes-agent
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes-agent/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./n8n/ks.yaml
   - ./librechat/ks.yaml
   - ./agentbox/ks.yaml
+  - ./hermes-agent/ks.yaml


### PR DESCRIPTION
## What

Re-provisions the Nous Research **Hermes Agent** (removed in #296) as a Flux-managed deployment in the `ai` namespace, alongside agentBox (coexists, does not replace).

Ships in **BOOTSTRAP mode**: both containers run `sleep infinity` so the pod comes up stable against a fresh Longhorn PVC. Once up, `hermes setup` (OpenAI Codex OAuth device flow) runs via `kubectl exec` to authenticate and write `auth.json` to the PVC. A follow-up PR flips to real commands and re-couples open-webui.

## Manifests

- `hermes-agent/ks.yaml` — Flux Kustomization, targetNamespace `ai`, `cluster-secrets` substitution
- `app/ocirepository.yaml` — bjw-s `app-template` 5.0.1
- `app/externalsecret-dotenv.yaml` — single `API_SERVER_KEY` from 1P `hermes-dotenv` (explicit `remoteRef.property`, not `dataFrom.extract`)
- `app/helmrelease.yaml` — 2-container pod (gateway + dashboard), Longhorn 20Gi PVC, NFS `5 Shared/hermes`, dotenv secret mount, internal route `hermes.\${SECRET_DOMAIN}`
- registered in `ai/kustomization.yaml`

## Deltas from the original deploy

- **Creds shrink to `API_SERVER_KEY` only.** OpenAI auth is OAuth-on-PVC, not a k8s secret. Telegram + Home Assistant deferred.
- ExternalSecret uses `remoteRef.property: password` to dodge the `notesPlain` extract collision.

## Follow-up (PR2, go-live)

- Flip `args` → `["gateway","run"]` and `["dashboard","--host","0.0.0.0","--no-open","--insecure"]` + HTTP probes on :9119
- Re-couple open-webui → `hermes-agent.ai.svc.cluster.local:8642` (restore `OPENAI_API_BASE_URL` + `open-webui-hermes` ExternalSecret)

## Prereqs (out of band)

- NFS share `5 Shared/hermes` recreated
- 1P `hermes-dotenv` item created with generated `API_SERVER_KEY`
- ChatGPT plan >= Plus required for the OAuth flow

https://claude.ai/code/session_01K48296HuCkVXbUo2t8YpbS