### PR TITLE
feat(hermes-agent): go live + re-couple open-webui

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -23,11 +23,7 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # BOOTSTRAP: entrypoint detects `sleep` as an executable and passes
-            # it through, activating the venv and scaffolding /opt/data before
-            # sleeping. Exec in to run `hermes setup` (OpenAI Codex OAuth device
-            # flow), then flip args to: ["gateway", "run"]
-            args: ["sleep", "infinity"]
+            args: ["gateway", "run"]
             env:
               HERMES_HOME: /opt/data
               PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
@@ -45,13 +41,22 @@ spec:
             image:
               repository: docker.io/nousresearch/hermes-agent
               tag: v2026.5.16
-            # BOOTSTRAP: same pattern — entrypoint runs, venv activated, then
-            # sleeps. After `hermes setup`, flip args to:
-            # ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
-            # and re-add the HTTP liveness/readiness probes (GET / :9119).
-            args: ["sleep", "infinity"]
+            args: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
             env:
               HERMES_HOME: /opt/data
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 9119
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness: *probes
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui-hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: open-webui-hermes-secret
+  data:
+    # Same API_SERVER_KEY that fronts the Hermes gateway API, sourced from the
+    # single hermes-dotenv 1Password item (password field). Lets open-webui
+    # authenticate to hermes-agent:8642 as an OpenAI-compatible backend.
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: hermes-dotenv
+        property: password

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -20,6 +20,12 @@ spec:
               OLLAMA_BASE_URL: "http://ollama.ai.svc.cluster.local:11434"
               WEBUI_AUTH: "true"
               ENABLE_SIGNUP: "false"
+              OPENAI_API_BASE_URL: "http://hermes-agent.ai.svc.cluster.local:8642/v1"
+              OPENAI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: open-webui-hermes-secret
+                    key: OPENAI_API_KEY
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/open-webui/app/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## What

Second half of the Hermes Agent revive (follow-up to #346). Bootstrap is complete — flips the deployment to real commands and reconnects open-webui.

**Verified end-to-end before shipping:** OpenAI provider authenticated via the Codex OAuth device flow (ChatGPT account, model **gpt-5.5**); `auth.json` + config persisted on the Longhorn PVC. A live `POST /v1/chat/completions` to `:8642` returned a valid completion.

## Changes

- **hermes-agent** — both containers flip from `sleep infinity` to real commands:
  - gateway → `["gateway","run"]` (API server on :8642 via existing container env)
  - dashboard → `["dashboard","--host","0.0.0.0","--no-open","--insecure"]` + restored HTTP liveness/readiness probes (GET / :9119)
- **open-webui** — re-coupled to `hermes-agent.ai.svc.cluster.local:8642/v1` as an OpenAI-compatible backend (`OPENAI_API_BASE_URL` + `OPENAI_API_KEY`); restored the `open-webui-hermes` ExternalSecret, now sourced from the single `hermes-dotenv` 1Password item (password field).

## Post-merge verification

- Fresh pod comes up 2/2 with gateway + dashboard serving
- Dashboard reachable at `hermes.${SECRET_DOMAIN}`
- open-webui lists the `hermes-agent` model and can chat through it

## Deferred (future PRs)

- Telegram bot interface (add creds to `hermes-dotenv`, wire `TELEGRAM_*`)
- Home Assistant gateway integration (`HASS_TOKEN` / `HASS_URL`)

https://claude.ai/code/session_01K48296HuCkVXbUo2t8YpbS