### PR TITLE
feat(tools): artifacts app — zero-deploy static hosting (Bridge plan 1)

### DIFF
--- a/kubernetes/apps/tools/artifacts/app/configmap.yaml
+++ b/kubernetes/apps/tools/artifacts/app/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: artifacts-caddyfile
+data:
+  Caddyfile: |
+    :8080 {
+      root * /srv/sites
+      file_server browse
+      header /*/ Cache-Control "no-cache"
+      encode gzip
+    }

--- a/kubernetes/apps/tools/artifacts/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/artifacts/app/helmrelease.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: artifacts
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: artifacts
+  interval: 1h
+  values:
+    controllers:
+      artifacts:
+        strategy: RollingUpdate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/library/caddy
+              tag: 2.10-alpine
+            args: ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]
+            env:
+              XDG_CONFIG_HOME: /config
+              XDG_DATA_HOME: /data
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    persistence:
+      sites:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/bridge/sites"
+        globalMounts:
+          - path: /srv/sites
+            readOnly: true
+      caddyfile:
+        type: configMap
+        name: artifacts-caddyfile
+        globalMounts:
+          - path: /etc/caddy
+            readOnly: true
+      config:
+        type: emptyDir
+        globalMounts:
+          - path: /config
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/tools/artifacts/app/httproute.yaml
+++ b/kubernetes/apps/tools/artifacts/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: artifacts
+spec:
+  hostnames:
+    - "art.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: artifacts
+          port: 8080

--- a/kubernetes/apps/tools/artifacts/app/kustomization.yaml
+++ b/kubernetes/apps/tools/artifacts/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./configmap.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/tools/artifacts/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/artifacts/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: artifacts
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/artifacts/ks.yaml
+++ b/kubernetes/apps/tools/artifacts/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: artifacts
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/artifacts/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./forgejo/ks.yaml
   - ./shlink/ks.yaml
   - ./apprise/ks.yaml
+  - ./artifacts/ks.yaml
   - ./zipline/ks.yaml
   - ./homepage/ks.yaml
   - ./glance/ks.yaml


### PR DESCRIPTION
## What

New \`tools/artifacts\` app: Caddy 2.10 (upstream image, no build) serving \`/volume1/syncthing/ic_documents/5 Shared/bridge/sites\` read-only over NFS, routed at \`art.${SECRET_DOMAIN}\` via **envoy-internal only**.

## Why

Bridge project plan 1 (artifact-layer): zero-deploy static artifact hosting. Drop \`sites/<name>/index.html\` + \`.ready\` on the share → live on the LAN in ~SyncThing interval, no git commit or cluster call per site.

## Notes

- Follows echo app shape (ks.yaml + app-template 5.0.1 OCI chart); NFS inline volume per plex/hermes pattern
- Caddyfile in a plain ConfigMap (no secrets); \`file_server browse\`, no-cache headers, gzip
- Pod: runAsNonRoot 65534, readOnlyRootFilesystem, emptyDir /config + /data for Caddy state
- **Internal gateway only** — external exposure deliberately excluded (Bridge decision log)
- \`kubectl kustomize\` renders clean (app + tools)
- Smoke-test site \`sites/hello/\` already on the share

After merge: verify \`curl -k https://art.<domain>/hello/\`, then /k8s-route-check to confirm not externally reachable.

https://claude.ai/code/session_01D5GSe1AT166979h7bNt6if