### PR TITLE
fix(tools): artifacts — add NET_BIND_SERVICE (caddy exec crash)

### DIFF
--- a/kubernetes/apps/tools/artifacts/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/artifacts/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
+              capabilities: { drop: ["ALL"], add: ["NET_BIND_SERVICE"] }
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
Pod from #349 crashloops: `exec /usr/bin/caddy: operation not permitted`. The official caddy image sets file capabilities on the binary; `drop: ALL` as non-root blocks the exec. Adds `NET_BIND_SERVICE` back — everything else unchanged.

Replaces #350 (attribution).

https://claude.ai/code/session_01D5GSe1AT166979h7bNt6if