### PR TITLE
feat(tools): bridge — agent dashboard shell (Bridge plan 2)

### DIFF
--- a/kubernetes/apps/tools/bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/bridge/app/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bridge
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: bridge
+  interval: 1h
+  values:
+    controllers:
+      bridge:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: docker.io/library/node
+              tag: 22-alpine
+            command: ["node", "/app/server.js"]
+            env:
+              PORT: &port "5100"
+              DATA_DIR: /data
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 5100
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        ports:
+          http:
+            port: 5100
+    persistence:
+      app:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/bridge/app"
+        globalMounts:
+          - path: /app
+            readOnly: true
+      data:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/bridge/data"
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/tools/bridge/app/httproute.yaml
+++ b/kubernetes/apps/tools/bridge/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bridge
+spec:
+  hostnames:
+    - "bridge.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: bridge
+          port: 5100

--- a/kubernetes/apps/tools/bridge/app/kustomization.yaml
+++ b/kubernetes/apps/tools/bridge/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/tools/bridge/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/bridge/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bridge
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/bridge/ks.yaml
+++ b/kubernetes/apps/tools/bridge/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: bridge
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/bridge/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./shlink/ks.yaml
   - ./apprise/ks.yaml
   - ./artifacts/ks.yaml
+  - ./bridge/ks.yaml
   - ./zipline/ks.yaml
   - ./homepage/ks.yaml
   - ./glance/ks.yaml


### PR DESCRIPTION
## What

New `tools/bridge` app: upstream `node:22-alpine` running the zero-dependency Bridge server whose code is **NFS-mounted read-only** from `5 Shared/bridge/app/` (released there via rsync — no image build, no CI). Runtime data on the same share at `bridge/data/`, mounted rw. Routed at `bridge.${SECRET_DOMAIN}` on **envoy-internal only**.

## Why

Bridge plan 2 (bridge-shell): the dashboard core — module auto-discovery, agent-status API, shell UI. Verified locally end-to-end (module contract, status dots, traversal guard); code already released to the share and synced to the NAS.

## Notes

- Same shape as `artifacts` (#349): ks.yaml + app-template 5.0.1, inline NFS volumes
- Pod: runAsNonRoot 65534, readOnlyRootFilesystem, drop ALL (node binary carries no file caps — the caddy #351 issue doesn't apply)
- Deploy loop after this: `scripts/release.sh` on the Mac + `kubectl -n tools rollout restart deploy/bridge`
- **No auth in v1 — internal route only** (hard rule in the project note: never external without an auth proxy)

After merge: verify `https://bridge.<domain>` serves the shell, then agent status hooks (plan task 4).

https://claude.ai/code/session_01D5GSe1AT166979h7bNt6if