### PR TITLE
feat(bridge): deliverables + sites read-only mounts (plan 4)

### DIFF
--- a/kubernetes/apps/tools/bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/bridge/app/helmrelease.yaml
@@ -21,6 +21,8 @@ spec:
             env:
               PORT: &port "5100"
               DATA_DIR: /data
+              VAULT_DELIVERABLES_DIR: /vault-deliverables
+              SITES_DIR: /sites
             probes:
               liveness: &probes
                 enabled: true
@@ -67,3 +69,17 @@ spec:
         path: "/volume1/syncthing/ic_documents/5 Shared/bridge/data"
         globalMounts:
           - path: /data
+      vault-deliverables:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_obsidian/lifeOS/3 Resources/deliverables"
+        globalMounts:
+          - path: /vault-deliverables
+            readOnly: true
+      sites:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_documents/5 Shared/bridge/sites"
+        globalMounts:
+          - path: /sites
+            readOnly: true


### PR DESCRIPTION
Two read-only NFS mounts for the Bridge deliverables module:

- `/vault-deliverables` ← `ic_obsidian/lifeOS/3 Resources/deliverables` (canonical vault deliverables — 31 files, path verified via agentbox mount)
- `/sites` ← `ic_documents/5 Shared/bridge/sites` (plan-1 artifact sites)

Plus `VAULT_DELIVERABLES_DIR` / `SITES_DIR` env for the module. Vault plan: Bridge plans/2026-07-06-deliverables-module.

https://claude.ai/code/session_01D5GSe1AT166979h7bNt6if