### PR TITLE
feat(bridge): plans 5-7 infra — vault mount, qdrant/apprise env, ExternalSecret

### DIFF
--- a/kubernetes/apps/tools/bridge/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/bridge/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bridge
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: bridge-secret
+    template:
+      data:
+        QDRANT_API_KEY: "{{ .qdrant_api_key }}"
+        DISCORD_WEBHOOK_URL: "{{ .discord_webhook }}"
+  data:
+    - secretKey: qdrant_api_key
+      remoteRef:
+        key: bridge
+        property: qdrant_api_key
+    - secretKey: discord_webhook
+      remoteRef:
+        key: discord-webhook-jarvis
+        property: password

--- a/kubernetes/apps/tools/bridge/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/bridge/app/helmrelease.yaml
@@ -23,6 +23,14 @@ spec:
               DATA_DIR: /data
               VAULT_DELIVERABLES_DIR: /vault-deliverables
               SITES_DIR: /sites
+              VAULT_DIR: /vault
+              APPRISE_URL: http://apprise.tools:8000/notify
+              QDRANT_URL: http://qdrant.ai:6333
+              OLLAMA_URL: http://ollama.ai:11434
+            envFrom:
+              - secretRef:
+                  name: bridge-secret
+                  optional: true
             probes:
               liveness: &probes
                 enabled: true
@@ -82,4 +90,11 @@ spec:
         path: "/volume1/syncthing/ic_documents/5 Shared/bridge/sites"
         globalMounts:
           - path: /sites
+            readOnly: true
+      vault:
+        type: nfs
+        server: ${NFS_SERVER}
+        path: "/volume1/syncthing/ic_obsidian/lifeOS"
+        globalMounts:
+          - path: /vault
             readOnly: true

--- a/kubernetes/apps/tools/bridge/app/kustomization.yaml
+++ b/kubernetes/apps/tools/bridge/app/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml


### PR DESCRIPTION
Infra for Bridge plans 5 (question-ledger notifications) and 7 (vault module):

- NFS **read-only** mount of the lifeOS vault at `/vault` (`VAULT_DIR`)
- In-cluster `QDRANT_URL`/`OLLAMA_URL` + `APPRISE_URL` envs
- `bridge-secret` via ESO — 1P `bridge/qdrant_api_key` + `discord-webhook-jarvis/password`; `optional: true` so the pod starts even before the 1P `bridge` item is created (that item creation is parked on an op-session biometric)

Module code lands separately via the NFS release flow (no image build).

https://claude.ai/code/session_01D5GSe1AT166979h7bNt6if