### PR TITLE
feat(mattermost): deploy Mattermost Team Edition (internal-only)

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -76,6 +76,7 @@ Validation is required for auth changes, route changes, new apps, and app remova
 | Audiobookshelf | internal | `forward_auth` | Built-in auth exists, but no native OIDC |
 | Grimmory | internal | `none` | Deployed internal-only first; auth deferred to a follow-up change |
 | Bambuddy | internal | `none` | Internal-only LAN access; built-in MFA suffices. Revisit forward_auth later. |
+| Mattermost | internal | `none` | Internal-only LAN access; built-in account auth suffices. Team Edition lacks native OIDC; revisit forward_auth later. |
 | OpenWebUI | internal | `native_oidc` | Native OIDC support |
 | n8n | internal | `native_oidc` | Prefer Authentik-backed OIDC when configured |
 | Teslamate | internal | `forward_auth` | No native OIDC |

--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -30,6 +30,14 @@ data:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 2000"
 
+      - name: Mattermost
+        group: tools
+        url: "https://matter.${SECRET_DOMAIN}/api/v4/system/ping"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+
       - name: Cloudflare
         group: external
         url: "https://1.1.1.1/cdn-cgi/trace"

--- a/kubernetes/apps/tools/db-backup/app/cronjob-mattermost.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-mattermost.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-mattermost
+spec:
+  schedule: "50 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: mattermost-secret
+                    key: db_password
+              - name: PGHOST
+                value: mattermost-postgres.tools.svc.cluster.local
+              - name: PGUSER
+                value: mattermost
+              - name: PGDATABASE
+                value: mattermost
+              - name: RETENTION_DAYS
+                value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/mattermost-${TS}.dump"
+                  echo "[$(date -u)] pg_dump mattermost -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning mattermost-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'mattermost-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/tools/db-backup/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./rbac.yaml
   - ./cronjob-atuin.yaml
   - ./cronjob-forgejo.yaml
+  - ./cronjob-mattermost.yaml
   - ./cronjob-nextcloud.yaml
   - ./cronjob-shlink.yaml
   - ./cronjob-zipline.yaml

--- a/kubernetes/apps/tools/homepage/app/configmap.yaml
+++ b/kubernetes/apps/tools/homepage/app/configmap.yaml
@@ -179,6 +179,11 @@ data:
             icon: sh-apprise
             href: https://apprise.${SECRET_DOMAIN}
             description: Notifications
+        - Mattermost:
+            icon: mattermost.svg
+            href: https://matter.${SECRET_DOMAIN}
+            description: Team Chat
+            siteMonitor: http://mattermost-main.tools.svc.cluster.local:8065
     - AI:
         - LibreChat:
             icon: librechat.svg

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -22,5 +22,6 @@ resources:
   - ./code-server/ks.yaml
   - ./webtop/ks.yaml
   - ./nextcloud/ks.yaml
+  - ./mattermost/ks.yaml
   # - ./syncthing/ks.yaml
   # - ./kms/ks.yaml ## Disabling for now, likely to archive later

--- a/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mattermost
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: mattermost-secret
+    template:
+      data:
+        db_password: "{{ .db_password }}"
+        MM_SQLSETTINGS_DATASOURCE: "postgres://mattermost:{{ .db_password }}@mattermost-postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
+  dataFrom:
+    - extract:
+        key: mattermost

--- a/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mattermost
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: mattermost
+  interval: 1h
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/mattermost/mattermost-team-edition
+              tag: 11.9.0
+            env:
+              MM_SERVICESETTINGS_SITEURL: "https://matter.${SECRET_DOMAIN}"
+              MM_SERVICESETTINGS_LISTENADDRESS: ":8065"
+              MM_SQLSETTINGS_DRIVERNAME: postgres
+              MM_SQLSETTINGS_DATASOURCE:
+                valueFrom:
+                  secretKeyRef:
+                    name: mattermost-secret
+                    key: MM_SQLSETTINGS_DATASOURCE
+              MM_FILESETTINGS_DIRECTORY: /mattermost/data/
+              MM_LOGSETTINGS_ENABLECONSOLE: "true"
+              MM_LOGSETTINGS_CONSOLELEVEL: INFO
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v4/system/ping
+                    port: 8065
+                  initialDelaySeconds: 60
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v4/system/ping
+                    port: 8065
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+
+      postgres:
+        strategy: Recreate
+        containers:
+          postgres:
+            image:
+              repository: postgres
+              tag: 18-alpine
+            env:
+              POSTGRES_DB: mattermost
+              POSTGRES_USER: mattermost
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: mattermost-secret
+                    key: db_password
+              PGDATA: /var/lib/postgresql/data/pgdata
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+        pod:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8065
+      postgres:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 25Gi
+        advancedMounts:
+          main:
+            app:
+              - path: /mattermost/data
+                subPath: data
+              - path: /mattermost/config
+                subPath: config
+              - path: /mattermost/logs
+                subPath: logs
+              - path: /mattermost/plugins
+                subPath: plugins
+              - path: /mattermost/client/plugins
+                subPath: client-plugins
+              - path: /mattermost/bleve-indexes
+                subPath: bleve-indexes
+      postgres-data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        advancedMounts:
+          postgres:
+            postgres:
+              - path: /var/lib/postgresql/data
+
+    route:
+      app:
+        hostnames: ["matter.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: mattermost-main
+                port: 8065

--- a/kubernetes/apps/tools/mattermost/app/kustomization.yaml
+++ b/kubernetes/apps/tools/mattermost/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tools/mattermost/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/mattermost/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mattermost
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/mattermost/ks.yaml
+++ b/kubernetes/apps/tools/mattermost/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mattermost
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/mattermost/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false


### PR DESCRIPTION
## What

Deploys Mattermost Team Edition 11.9.0 to the `tools` namespace, internal-only, following the nextcloud pattern (app-template 5.0.1 + bundled postgres:18-alpine).

## Decisions (per Shawn, 2026-07-15)
- **Edition:** Team Edition (free)
- **Hostname:** `matter.${SECRET_DOMAIN}` on `envoy-internal` (`chat.` was taken by Open WebUI)
- **Storage:** 25Gi Longhorn PVC — single volume, subPath mounts for data/config/logs/plugins/client-plugins/bleve-indexes; separate 5Gi PVC for postgres
- **Auth mode:** `none` (built-in accounts) — recorded in the classification matrix; TE has no native OIDC, forward_auth can be layered later
- **Add-ons:** db-backup pg_dump cronjob (01:50 daily, 14d retention), Gatus endpoint (`/api/v4/system/ping`, new `tools` group), Homepage tile under Tools

## Validation
- `task validate:flux` — 138 passed
- `task validate:routes` — `mattermost-main` backendRef matches rendered service ✓
- `task validate:images` — `docker.io/mattermost/mattermost-team-edition:11.9.0` ✓
- `task validate:secrets` — 1P item `mattermost` exists, all fields matched ✓
- `task validate:secret-keys` / `validate:substitutions` — clean

## Ready to merge
1Password item `mattermost` (field `db_password`, symbol-free — embedded in the postgres DSN) created and validated.

After merge + first boot: create the first admin account promptly (first signup gets system admin).

https://claude.ai/code/session_01SRQABixoRs5t7WjzYfcdFq