### PR TITLE
feat(hermes-agent): wire Mattermost platform connector

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -13,15 +13,30 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Only the API server key is provisioned via secret. The OpenAI/ChatGPT
-        # provider credential is obtained interactively via the Codex OAuth
-        # device flow (`hermes setup`) and persists in auth.json on the PVC, not
-        # here. Telegram/Home Assistant creds are deferred — add fields to the
-        # hermes-dotenv 1Password item and reference them here when enabling.
+        # The OpenAI/ChatGPT provider credential is obtained interactively via
+        # the Codex OAuth device flow (`hermes setup`) and persists in
+        # auth.json on the PVC, not here. Telegram/Home Assistant creds are
+        # still deferred — add fields to the hermes-dotenv 1Password item and
+        # reference them here when enabling.
+        #
+        # Mattermost is wired: the gateway auto-enables the bundled Mattermost
+        # platform adapter purely from MATTERMOST_URL/MATTERMOST_TOKEN
+        # presence (no HelmRelease/config.yaml change needed). Bot account
+        # "hermes" lives in the mixos team; access is open to any user in
+        # this (internal-only) instance; MATTERMOST_HOME_CHANNEL points at
+        # the dedicated #hermes-home channel for cron/proactive delivery.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
+          MATTERMOST_URL=http://mattermost-main.tools.svc.cluster.local:8065
+          MATTERMOST_TOKEN={{ .MATTERMOST_TOKEN }}
+          MATTERMOST_ALLOW_ALL_USERS=true
+          MATTERMOST_HOME_CHANNEL=4qkyyzxfejdtuqpdkkiatbemur
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:
         key: hermes-dotenv
         property: password
+    - secretKey: MATTERMOST_TOKEN
+      remoteRef:
+        key: hermes-dotenv
+        property: MATTERMOST_TOKEN


### PR DESCRIPTION
## Summary
- Hermes ships a bundled Mattermost adapter that auto-enables purely from `MATTERMOST_URL`/`MATTERMOST_TOKEN` presence — no HelmRelease or `config.yaml` change needed, just the `hermes-dotenv` ExternalSecret.
- Adds `MATTERMOST_ALLOW_ALL_USERS=true` (open access — instance is internal-only) and `MATTERMOST_HOME_CHANNEL` (dedicated `#hermes-home` channel for cron/proactive delivery).
- Bot account `hermes` created in the `mixos` team via `mmctl --local`, joined to `#hermes-home` and `#town-square`; access token stored in the `hermes-dotenv` 1Password item (`MATTERMOST_TOKEN` field, already populated).

## Test plan
- [x] `hermes-dotenv` 1Password item has `MATTERMOST_TOKEN` field populated (verified length, not value)
- [ ] After merge: force-sync the ExternalSecret and confirm `mattermost-secret`/`hermes-dotenv` renders all `MATTERMOST_*` lines
- [ ] `kubectl rollout restart deploy/hermes-agent -n ai`; check gateway logs for successful Mattermost WebSocket connect
- [ ] DM the `hermes` bot in Mattermost and confirm a reply
- [ ] @mention `@hermes` in `#town-square` and confirm a reply

https://claude.ai/code/session_01TrdhkSdUoUr49AY2qQj1tE