### PR TITLE
feat(hermes-agent): use threaded replies for Mattermost mentions

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -25,12 +25,15 @@ spec:
         # "hermes" lives in the mixos team; access is open to any user in
         # this (internal-only) instance; MATTERMOST_HOME_CHANNEL points at
         # the dedicated #hermes-home channel for cron/proactive delivery.
+        # MATTERMOST_REPLY_MODE=thread keeps @mention/channel replies in the
+        # originating thread instead of posting new root messages.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           MATTERMOST_URL=http://mattermost-main.tools.svc.cluster.local:8065
           MATTERMOST_TOKEN={{ .MATTERMOST_TOKEN }}
           MATTERMOST_ALLOW_ALL_USERS=true
           MATTERMOST_HOME_CHANNEL=4qkyyzxfejdtuqpdkkiatbemur
+          MATTERMOST_REPLY_MODE=thread
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:


### PR DESCRIPTION
## Summary
- Follow-up to #367. Sets `MATTERMOST_REPLY_MODE=thread` in the `hermes-dotenv` ExternalSecret so the Hermes bot's replies to @mentions/channel messages stay anchored in the originating thread instead of posting new root messages.

## Test plan
- [ ] After merge: reconcile + restart `hermes-agent`
- [ ] @mention `@hermes` in a channel and confirm the reply appears as a threaded reply, not a new root post

https://claude.ai/code/session_01TrdhkSdUoUr49AY2qQj1tE