### PR TITLE
fix(authentik): drop duplicate passwordless-login blueprint

### DIFF
--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -16,7 +16,6 @@ resources:
 configMapGenerator:
   - name: authentik-blueprints
     files:
-      - blueprints/passwordless-passkey.yaml
       - blueprints/setup-passkey.yaml
 
 generatorOptions:


### PR DESCRIPTION
Follow-up to #369. Live verification showed a pre-existing, correctly configured `passwordless-authentication` flow already wired to the login page (webauthn validate w/ `user_verification: required` + `default-authentication-login`). The `passwordless-passkey.yaml` blueprint recreated that flow — redundant, and it errored on apply.

The real missing piece was **discoverable/resident-key enrollment**, delivered by `setup-passkey.yaml` (applied successfully in #369). This removes the duplicate login blueprint and keeps enrollment. Existing flow + wiring untouched.

Net result: passkey login uses the existing flow; users can now enroll a resident-key passkey at `/if/flow/setup-passkey/`.

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync