### PR TITLE
feat(sso): Authentik OIDC SSO for Headlamp + Mattermost

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: headlamp-secret
+    template:
+      data:
+        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+  dataFrom:
+    - extract:
+        key: headlamp

--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -20,6 +20,13 @@ spec:
               - -in-cluster
               - -plugins-dir
               - /headlamp/plugins
+            env:
+              # OIDC login via Authentik. CLIENT_ID/SECRET come from headlamp-secret.
+              OIDC_IDP_ISSUER_URL: https://auth.${SECRET_DOMAIN}/application/o/headlamp/
+              OIDC_SCOPES: openid,email,profile
+            envFrom:
+              - secretRef:
+                  name: headlamp-secret
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/monitoring/headlamp/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./rbac.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/monitoring/headlamp/app/rbac.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/rbac.yaml
@@ -17,3 +17,19 @@ subjects:
   - kind: ServiceAccount
     name: headlamp
     namespace: monitoring
+---
+# Bind the Authentik OIDC identity (kube-apiserver oidc-username-claim=email)
+# to cluster-admin so the id_token Headlamp forwards is authorized by the API.
+# Requires the apiserver OIDC trust configured in Talos (talos/patches).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-oidc-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: User
+    name: shawnmix@gmail.com
+    apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       data:
         db_password: "{{ .db_password }}"
         MM_SQLSETTINGS_DATASOURCE: "postgres://mattermost:{{ .db_password }}@mattermost-postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
+        # Authentik OIDC (consumed via Mattermost TE's GitLab OAuth override)
+        MM_GITLABSETTINGS_ID: "{{ .oidc_client_id }}"
+        MM_GITLABSETTINGS_SECRET: "{{ .oidc_client_secret }}"
   dataFrom:
     - extract:
         key: mattermost

--- a/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
@@ -22,6 +22,25 @@ spec:
             env:
               MM_SERVICESETTINGS_SITEURL: "https://matter.${SECRET_DOMAIN}"
               MM_SERVICESETTINGS_LISTENADDRESS: ":8065"
+              # --- SSO via Authentik (Team Edition uses the GitLab OAuth slot,
+              # with endpoints overridden to point at Authentik). The custom
+              # Authentik "mattermost" scope returns GitLab-shaped claims
+              # (id/username/login/email/name) that MM's GitLab parser expects. ---
+              MM_GITLABSETTINGS_ENABLE: "true"
+              MM_GITLABSETTINGS_SCOPE: "openid email profile mattermost"
+              MM_GITLABSETTINGS_AUTHENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/authorize/"
+              MM_GITLABSETTINGS_TOKENENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/token/"
+              MM_GITLABSETTINGS_USERAPIENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/userinfo/"
+              MM_GITLABSETTINGS_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: mattermost-secret
+                    key: MM_GITLABSETTINGS_ID
+              MM_GITLABSETTINGS_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: mattermost-secret
+                    key: MM_GITLABSETTINGS_SECRET
               MM_SQLSETTINGS_DRIVERNAME: postgres
               MM_SQLSETTINGS_DATASOURCE:
                 valueFrom:

--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -8,6 +8,14 @@ cluster:
       enable-aggregator-routing: true
       # Reduce per-resource watch cache from default 100 to 50 — homelab scale doesn't need full cache
       default-watch-cache-size: "50"
+      # OIDC trust for Authentik (enables Headlamp SSO — the id_token Headlamp
+      # forwards is validated by the apiserver against this issuer). Additive:
+      # existing admin client-cert / static kubeconfig auth is unaffected.
+      # NOTE: applied out-of-band via `talosctl apply-config` (not Flux).
+      oidc-issuer-url: https://auth.thegeekybits.com/application/o/headlamp/
+      oidc-client-id: WxrKDa2ZRlFrT52GxJVz6wJuQxRSDw7RIAicrGP9
+      oidc-username-claim: email
+      oidc-groups-claim: groups
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0


### PR DESCRIPTION
## Goal
Log into Headlamp and Mattermost with the Authentik account (shawnmix@gmail.com): click login → redirect to Authentik if needed → already-logged-in drops straight in.

## Authentik side (created live, secrets in 1Password)
- OIDC providers + apps: `headlamp`, `mattermost` — implicit-consent authz flow (already-logged-in = no prompt).
- Custom scope `mattermost` returns GitLab-shaped claims (`id`=user pk, `username`, `login`, `email`, `name`) for MM Team Edition.
- Codifying these to in-repo blueprints is a follow-up.

## Headlamp
- Native OIDC via `OIDC_*` env (client id/secret from new `headlamp` ExternalSecret; issuer `auth.${SECRET_DOMAIN}/application/o/headlamp/`).
- `headlamp-oidc-admin` ClusterRoleBinding → cluster-admin for User `shawnmix@gmail.com`.
- **Requires apiserver OIDC trust** — staged in `talos/patches/controller/cluster.yaml`. Applied out-of-band via `talosctl` (NOT Flux). Until applied, Headlamp login succeeds but the dashboard is empty (API rejects the token). Additive/reversible — existing admin kubeconfig auth unaffected.

## Mattermost (Team Edition)
- TE's only native SSO is GitLab OAuth; endpoints overridden to Authentik (`authorize`/`token`/`userinfo`). Client id/secret via ExternalSecret.
- Existing account gets linked by pre-setting `authservice=gitlab`, `authdata=<Authentik pk>` on the MM user (done post-merge, out-of-band).

## Post-merge steps (tracked, some gated)
1. Apply Talos apiserver patch (gated — needs explicit go).
2. Pre-link the MM user row for account tie-in.
3. End-to-end login test both apps.

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync