### PR TITLE
fix(mattermost): use OpenID Connect for Authentik SSO (GitLab provider gone in MM 11)

### DIFF
--- a/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
@@ -14,9 +14,9 @@ spec:
       data:
         db_password: "{{ .db_password }}"
         MM_SQLSETTINGS_DATASOURCE: "postgres://mattermost:{{ .db_password }}@mattermost-postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
-        # Authentik OIDC (consumed via Mattermost TE's GitLab OAuth override)
-        MM_GITLABSETTINGS_ID: "{{ .oidc_client_id }}"
-        MM_GITLABSETTINGS_SECRET: "{{ .oidc_client_secret }}"
+        # Authentik OIDC (Mattermost OpenID Connect provider)
+        MM_OPENIDSETTINGS_ID: "{{ .oidc_client_id }}"
+        MM_OPENIDSETTINGS_SECRET: "{{ .oidc_client_secret }}"
   dataFrom:
     - extract:
         key: mattermost

--- a/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
@@ -22,25 +22,26 @@ spec:
             env:
               MM_SERVICESETTINGS_SITEURL: "https://matter.${SECRET_DOMAIN}"
               MM_SERVICESETTINGS_LISTENADDRESS: ":8065"
-              # --- SSO via Authentik (Team Edition uses the GitLab OAuth slot,
-              # with endpoints overridden to point at Authentik). The custom
-              # Authentik "mattermost" scope returns GitLab-shaped claims
-              # (id/username/login/email/name) that MM's GitLab parser expects. ---
-              MM_GITLABSETTINGS_ENABLE: "true"
-              MM_GITLABSETTINGS_SCOPE: "openid email profile mattermost"
-              MM_GITLABSETTINGS_AUTHENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/authorize/"
-              MM_GITLABSETTINGS_TOKENENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/token/"
-              MM_GITLABSETTINGS_USERAPIENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/userinfo/"
-              MM_GITLABSETTINGS_ID:
+              # --- SSO via Authentik (OpenID Connect) ---
+              # Mattermost 11 no longer registers a GitLab OAuth provider
+              # (no EnableSignUpWithGitLab in client config -> /oauth/gitlab/login
+              # returns 501), so generic OpenID Connect is the supported path.
+              # DiscoveryEndpoint lets MM auto-resolve authorize/token/userinfo,
+              # and standard OIDC claims are used (no custom scope needed).
+              MM_OPENIDSETTINGS_ENABLE: "true"
+              MM_OPENIDSETTINGS_SCOPE: "profile openid email"
+              MM_OPENIDSETTINGS_BUTTONTEXT: "Log in with Authentik"
+              MM_OPENIDSETTINGS_DISCOVERYENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/mattermost/.well-known/openid-configuration"
+              MM_OPENIDSETTINGS_ID:
                 valueFrom:
                   secretKeyRef:
                     name: mattermost-secret
-                    key: MM_GITLABSETTINGS_ID
-              MM_GITLABSETTINGS_SECRET:
+                    key: MM_OPENIDSETTINGS_ID
+              MM_OPENIDSETTINGS_SECRET:
                 valueFrom:
                   secretKeyRef:
                     name: mattermost-secret
-                    key: MM_GITLABSETTINGS_SECRET
+                    key: MM_OPENIDSETTINGS_SECRET
               MM_SQLSETTINGS_DRIVERNAME: postgres
               MM_SQLSETTINGS_DATASOURCE:
                 valueFrom:


### PR DESCRIPTION
## Problem
PR #372 wired Mattermost SSO through the GitLab OAuth slot (the classic Team Edition workaround). It does not work on MM 11.9: `/oauth/gitlab/login` returns **501 'Gitlab SSO through OAuth 2.0 not available on this server'** even with all `MM_GITLABSETTINGS_*` correctly set on the pod and non-empty client id/secret.

Root cause: **MM 11 no longer registers a GitLab OAuth provider.** The client config exposes `EnableSignUpWithGoogle/Office365/OpenId/Saml` but **no** `EnableSignUpWithGitLab`. The `GitLabSettings` struct still exists in config.json, so the misconfig is silent until the login route is exercised.

## Fix
Use the supported generic **OpenID Connect** provider (`OpenIdSettings`):
- `MM_OPENIDSETTINGS_ENABLE/ID/SECRET/SCOPE/BUTTONTEXT` + `DISCOVERYENDPOINT` (auto-resolves authorize/token/userinfo).
- Standard OIDC claims → the custom GitLab-shaped Authentik scope is **no longer needed** (removed from provider, mapping deleted).
- Authentik redirect URIs updated to `/signup/openid/complete` + `/login/openid/complete`.
- ExternalSecret keys renamed `MM_GITLABSETTINGS_*` → `MM_OPENIDSETTINGS_*`.

## Verification
Post-merge: `/oauth/openid/login` must 302 to Authentik's authorize endpoint (the 501 is the regression signal).

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync