### PR TITLE
revert(mattermost): drop SSO config — Team Edition v11 has no SSO path

### DIFF
--- a/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/mattermost/app/externalsecret.yaml
@@ -14,9 +14,6 @@ spec:
       data:
         db_password: "{{ .db_password }}"
         MM_SQLSETTINGS_DATASOURCE: "postgres://mattermost:{{ .db_password }}@mattermost-postgres:5432/mattermost?sslmode=disable&connect_timeout=10"
-        # Authentik OIDC (Mattermost OpenID Connect provider)
-        MM_OPENIDSETTINGS_ID: "{{ .oidc_client_id }}"
-        MM_OPENIDSETTINGS_SECRET: "{{ .oidc_client_secret }}"
   dataFrom:
     - extract:
         key: mattermost

--- a/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mattermost/app/helmrelease.yaml
@@ -22,26 +22,16 @@ spec:
             env:
               MM_SERVICESETTINGS_SITEURL: "https://matter.${SECRET_DOMAIN}"
               MM_SERVICESETTINGS_LISTENADDRESS: ":8065"
-              # --- SSO via Authentik (OpenID Connect) ---
-              # Mattermost 11 no longer registers a GitLab OAuth provider
-              # (no EnableSignUpWithGitLab in client config -> /oauth/gitlab/login
-              # returns 501), so generic OpenID Connect is the supported path.
-              # DiscoveryEndpoint lets MM auto-resolve authorize/token/userinfo,
-              # and standard OIDC claims are used (no custom scope needed).
-              MM_OPENIDSETTINGS_ENABLE: "true"
-              MM_OPENIDSETTINGS_SCOPE: "profile openid email"
-              MM_OPENIDSETTINGS_BUTTONTEXT: "Log in with Authentik"
-              MM_OPENIDSETTINGS_DISCOVERYENDPOINT: "https://auth.${SECRET_DOMAIN}/application/o/mattermost/.well-known/openid-configuration"
-              MM_OPENIDSETTINGS_ID:
-                valueFrom:
-                  secretKeyRef:
-                    name: mattermost-secret
-                    key: MM_OPENIDSETTINGS_ID
-              MM_OPENIDSETTINGS_SECRET:
-                valueFrom:
-                  secretKeyRef:
-                    name: mattermost-secret
-                    key: MM_OPENIDSETTINGS_SECRET
+              # NOTE: No SSO here by design. Mattermost Team Edition v11 has no
+              # working SSO path — v11.0 removed GitLab SSO from TE, and OpenID
+              # Connect is license-gated (utils/license.go Features.OpenId). The
+              # TE image is built BuildEnterpriseReady=false, so it holds no
+              # license and the gate can never pass: MM_OPENIDSETTINGS_* load
+              # into config but EnableSignUpWithOpenId is forced false and
+              # /oauth/openid/login returns 501. Authentik SSO would require the
+              # mattermost-enterprise-edition image run unlicensed (free "Entry"
+              # tier, which carries a 10k channel-message history cap).
+              # Decision 2026-07-17: stay on TE with email/password auth.
               MM_SQLSETTINGS_DRIVERNAME: postgres
               MM_SQLSETTINGS_DATASOURCE:
                 valueFrom:


### PR DESCRIPTION
## Why
PRs #372 (GitLab OAuth slot) and #373 (OpenID Connect) were both dead config. **Mattermost Team Edition v11 cannot do SSO at all:**

- **GitLab SSO removed in v11.0** — [deprecated features](https://docs.mattermost.com/product-overview/deprecated-features.html): *"GitLab SSO has been deprecated from Team Edition."* Last supported: v10.11 ESR. Confirmed live: `/oauth/gitlab/login` → **501**, and no `EnableSignUpWithGitLab` key in client config.
- **OpenID Connect is license-gated** (`Features.OpenId`) — [OIDC docs](https://docs.mattermost.com/administration-guide/onboard/sso-openidconnect.html): available on Entry/Professional/Enterprise, **not** Team Edition. The TE image is `BuildEnterpriseReady=false` so it holds no license. Confirmed live: `MM_OPENIDSETTINGS_*` present on the pod, yet `EnableSignUpWithOpenId=false`, `OpenIdButtonText=''`, `/oauth/openid/login` → **501**.

Both failure modes are **silent** (the `GitLabSettings`/`OpenIdSettings` structs still exist in config.json), which is why this only surfaced when the login route was actually exercised.

## Change
Remove the non-functional env + ExternalSecret keys; leave a comment documenting why, so it isn't re-attempted.

## Path to SSO (not taken)
Switch image to `mattermost/mattermost-enterprise-edition` with **no license** → free **Entry** tier includes full SSO. Cost: **10,000 channel-message history cap** (server-wide). Decision 2026-07-17: stay on TE, keep unlimited history + email/password.

Also reverted out-of-band: the MM user row pre-link (`authservice=gitlab`) — that disables password login, so it was cleared back to email/password auth.

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync