### PR TITLE
fix(headlamp): use HEADLAMP_CONFIG_ env prefix so OIDC is actually read

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/externalsecret.yaml
@@ -12,8 +12,12 @@ spec:
     name: headlamp-secret
     template:
       data:
-        OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
-        OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
+        # Headlamp parses config with koanf using the HEADLAMP_CONFIG_ env
+        # prefix (HEADLAMP_CONFIG_OIDC_CLIENT_ID -> -oidc-client-id). Bare
+        # OIDC_CLIENT_ID is silently ignored — auth_type stays "" and no login
+        # button appears.
+        HEADLAMP_CONFIG_OIDC_CLIENT_ID: "{{ .oidc_client_id }}"
+        HEADLAMP_CONFIG_OIDC_CLIENT_SECRET: "{{ .oidc_client_secret }}"
   dataFrom:
     - extract:
         key: headlamp

--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -22,8 +22,11 @@ spec:
               - /headlamp/plugins
             env:
               # OIDC login via Authentik. CLIENT_ID/SECRET come from headlamp-secret.
-              OIDC_IDP_ISSUER_URL: https://auth.${SECRET_DOMAIN}/application/o/headlamp/
-              OIDC_SCOPES: openid,email,profile
+              # Headlamp reads config via koanf under the HEADLAMP_CONFIG_ prefix
+              # (HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL -> -oidc-idp-issuer-url).
+              # Bare OIDC_* names are silently ignored.
+              HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL: https://auth.${SECRET_DOMAIN}/application/o/headlamp/
+              HEADLAMP_CONFIG_OIDC_SCOPES: openid,email,profile
             envFrom:
               - secretRef:
                   name: headlamp-secret


### PR DESCRIPTION
## Problem
PR #372 set bare `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_IDP_ISSUER_URL` / `OIDC_SCOPES`. **Headlamp silently ignores them.** The vars were confirmed present inside the container, yet:
- `/config` reported `auth_type: ""` (should be `"oidc"`)
- `/oidc` returned 200 instead of redirecting to the IdP

→ no login button, no SSO. Silent failure.

## Cause
Headlamp parses config with **koanf using the `HEADLAMP_CONFIG_` prefix** — `HEADLAMP_CONFIG_OIDC_CLIENT_ID` maps to the `-oidc-client-id` flag.

## Verification (empirical, in-pod)
Ran `headlamp-server` with `HEADLAMP_CONFIG_OIDC_*` set → `/config` `auth_type` flips to **`"oidc"`**.

## Related verified facts
The rest of the chain is already proven end-to-end with a real Authentik-issued id_token:
- apiserver authenticates `shawnmix@gmail.com`, groups `[tier1, authentik Admins]`
- `SelfSubjectAccessReview` → *allowed by ClusterRoleBinding "headlamp-oidc-admin" of ClusterRole "cluster-admin"*
- real `GET /api/v1/nodes` as that identity returns all 3 nodes

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync