### PR TITLE
fix(headlamp): add offline_access scope so OIDC login completes

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -26,7 +26,11 @@ spec:
               # (HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL -> -oidc-idp-issuer-url).
               # Bare OIDC_* names are silently ignored.
               HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL: https://auth.${SECRET_DOMAIN}/application/o/headlamp/
-              HEADLAMP_CONFIG_OIDC_SCOPES: openid,email,profile
+              # offline_access is required: Headlamp refreshes the id_token on
+              # every API call and hard-fails login ("refreshing token: getting
+              # refresh token: key not found") if the IdP issued no refresh
+              # token. authentik only returns one when offline_access is granted.
+              HEADLAMP_CONFIG_OIDC_SCOPES: openid,email,profile,offline_access
             envFrom:
               - secretRef:
                   name: headlamp-secret


### PR DESCRIPTION
## Problem (reported with screenshot)
Headlamp login button → popup → Authentik login succeeds → popup shows **'Redirecting to main page...'** and hangs; main window stays on the sign-in screen.

Backend logs: `refreshing token: getting refresh token: key not found`.

## Cause
Headlamp refreshes the id_token on API calls and **hard-fails login if no refresh token was stored.** authentik only issues a refresh token when `offline_access` is granted (authorization_code grant). Prior scope was `openid,email,profile` — no refresh token → login loop.

## Fix
- Request `offline_access` (this PR).
- Added the `offline_access` scope mapping to the headlamp provider in authentik.

## Note on prior 'verified' claim
Earlier end-to-end proof used a **minted** id_token against the apiserver — it validated the token→apiserver→RBAC chain (all correct) but did NOT exercise the browser popup + server-side code exchange + refresh, which is where this failed. Being verified now via a real browser login.

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync