### PR TITLE
feat(authentik): codify Headlamp OIDC as a blueprint

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/headlamp-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/headlamp-oidc.yaml
@@ -1,0 +1,74 @@
+# Headlamp OIDC SSO — config-as-code.
+#
+# Codifies the authentik side of Headlamp SSO (was created live via `ak shell`):
+#   - a Headlamp-scoped `email` mapping that sets email_verified=true, which the
+#     kube-apiserver REQUIRES when oidc-username-claim=email (the global default
+#     `email` mapping hardcodes email_verified=false and is intentionally left
+#     untouched — grafana/gatus/etc. share it);
+#   - the OIDC provider (authorization_code + refresh_token; offline_access is in
+#     property_mappings so a refresh token is issued — Headlamp hard-fails login
+#     without one);
+#   - the application.
+#
+# client_id is PINNED so it stays consistent with the kube-apiserver
+# `oidc-client-id` (talos/patches/controller/cluster.yaml) and the 1Password
+# `headlamp` item across rebuilds.
+#
+# client_secret is intentionally OMITTED: on the live instance authentik leaves
+# it unchanged, so applying this never disturbs the working provider. On a
+# from-scratch rebuild authentik regenerates it — read the new secret from
+# Authentik > Providers > headlamp and update the 1Password `headlamp` item
+# (field oidc_client_secret); the headlamp ExternalSecret then repopulates it.
+version: 1
+metadata:
+  name: headlamp-oidc
+entries:
+  - model: authentik_providers_oauth2.scopemapping
+    id: scope-headlamp-email
+    identifiers:
+      name: headlamp-email-verified
+    attrs:
+      scope_name: email
+      description: "email + email_verified=true for k8s OIDC (Headlamp)"
+      expression: |
+        return {
+            "email": request.user.email,
+            "email_verified": True,
+        }
+
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-headlamp
+    identifiers:
+      name: headlamp
+    attrs:
+      client_type: confidential
+      client_id: WxrKDa2ZRlFrT52GxJVz6wJuQxRSDw7RIAicrGP9
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      issuer_mode: per_provider
+      grant_types:
+        - authorization_code
+        - refresh_token
+      redirect_uris:
+        - matching_mode: strict
+          url: https://headlamp.thegeekybits.com/oidc-callback
+      authorization_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      signing_key:
+        !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+      property_mappings:
+        - !KeyOf scope-headlamp-email
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-offline_access"]]
+
+  - model: authentik_core.application
+    id: app-headlamp
+    identifiers:
+      slug: headlamp
+    attrs:
+      name: Headlamp
+      provider: !KeyOf provider-headlamp
+      policy_engine_mode: any

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
   - name: authentik-blueprints
     files:
       - blueprints/setup-passkey.yaml
+      - blueprints/headlamp-oidc.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## Why
The Headlamp OIDC provider, application, and the Headlamp-scoped `email` mapping (email_verified=true — required by the kube-apiserver, without disturbing the global default that grafana/gatus share) were created live via `ak shell` and lived only in authentik's DB (nightly-backed-up, not in git). This codifies them as a mounted blueprint, like the passkey config, so they survive a rebuild.

## Safety
Validated dry-run against the live instance — `Importer.validate() = True`, and it **adopts the existing objects by identifier** (provider pk=14, same scopemapping/application) rather than duplicating.
- `client_id` pinned → stays consistent with the apiserver `oidc-client-id` and the 1Password `headlamp` item across rebuilds.
- `client_secret` **omitted** → applying never touches the live provider's secret. On a from-scratch rebuild authentik regenerates it; re-sync to 1Password (documented in the blueprint header).

## Scope
authentik-side config only. No change to Headlamp, the apiserver, or RBAC (all already merged + verified end-to-end via a real browser login).

https://claude.ai/code/session_01Lu8a3bxQLwq4qCsp24Bync