### PR TITLE
feat(matrix): Synapse + MAS + Element Web (internal-only, Authentik SSO)

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -77,6 +77,9 @@ Validation is required for auth changes, route changes, new apps, and app remova
 | Grimmory | internal | `none` | Deployed internal-only first; auth deferred to a follow-up change |
 | Bambuddy | internal | `none` | Internal-only LAN access; built-in MFA suffices. Revisit forward_auth later. |
 | Mattermost | internal | `none` | Internal-only LAN access; built-in account auth suffices. Team Edition lacks native OIDC; revisit forward_auth later. |
+| Synapse | internal | `native_oidc` | Auth fully delegated to MAS, which uses Authentik as its only upstream provider. Federation disabled; no local passwords. |
+| MAS | internal | `native_oidc` | Matrix Authentication Service; login UI redirects to Authentik (sole upstream OIDC provider). Password auth disabled. |
+| Element | internal | `native_oidc` | Static client; auth flows through Synapse -> MAS -> Authentik. No auth of its own. |
 | OpenWebUI | internal | `native_oidc` | Native OIDC support |
 | n8n | internal | `native_oidc` | Prefer Authentik-backed OIDC when configured |
 | Teslamate | internal | `forward_auth` | No native OIDC |

--- a/docs/deployment-plan.md
+++ b/docs/deployment-plan.md
@@ -333,4 +333,5 @@ This section is the **source of truth** for tracking progress across sessions. U
 | 2026-03-07 | Reconciliation and auth governance | Reconciled the tracker against the live cluster, documented the auth standard, and removed Uptime Kuma from the planned stack in favor of Gatus. |
 | 2026-03-30 | MeTube stability tuning | Confirmed `OOMKilled` restarts during queued download processing and raised MeTube memory limit to `3Gi` while keeping concurrent downloads at `3` to preserve throughput. |
 | 2026-04-01 | Homepage Kubernetes widget fix | Added Homepage's missing in-cluster Kubernetes config and a dedicated service account binding so the Kubernetes status widget can authenticate against the cluster API. |
+| 2026-07-17 | Matrix stack | Deployed Synapse + Matrix Authentication Service (MAS) + Element Web (tools namespace, internal-only, `native_oidc` via MAS -> Authentik). Authentik provider codified as blueprint. DB dump cronjobs + Gatus endpoints added. |
 | | | *Next: Continue with Phase 4 and remaining auth cleanup.* |

--- a/kubernetes/apps/monitoring/gatus/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/configmap.yaml
@@ -38,6 +38,30 @@ data:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 2000"
 
+      - name: Synapse
+        group: tools
+        url: "https://synapse.${SECRET_DOMAIN}/health"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+
+      - name: MAS
+        group: tools
+        url: "https://mas.${SECRET_DOMAIN}/"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+
+      - name: Element
+        group: tools
+        url: "https://matrix.${SECRET_DOMAIN}/"
+        interval: 5m
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 2000"
+
       - name: Cloudflare
         group: external
         url: "https://1.1.1.1/cdn-cgi/trace"

--- a/kubernetes/apps/security/authentik/app/blueprints/matrix-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/matrix-oidc.yaml
@@ -1,0 +1,60 @@
+# Matrix (MAS) OIDC SSO — config-as-code.
+#
+# Authentik side of Matrix SSO. Users log in through the Matrix Authentication
+# Service (MAS), which delegates upstream to this provider — Element/Element X
+# never talk to authentik directly. MAS's upstream_oauth2 provider config lives
+# in the mas ExternalSecret (kubernetes/apps/tools/mas/app/externalsecret.yaml).
+#
+# client_id is PINNED so it stays consistent with the MAS config and survives
+# rebuilds. The redirect URI embeds MAS's pinned upstream-provider ULID and
+# must match byte-exactly (trailing slash included/excluded exactly as below).
+#
+# client_secret is intentionally OMITTED: authentik generates one on first
+# apply — read it from Authentik > Providers > matrix and store it in the
+# 1Password `mas` item (field authentik_client_secret); the mas ExternalSecret
+# then renders it into MAS's config.
+#
+# sub_mode is user_username so the MAS<->authentik account link is stable and
+# matches the localpart claim import (preferred_username) on the MAS side.
+#
+# Signing key: the RSA "authentik Self-signed Certificate" — MAS/Synapse
+# require RS256; do not switch this provider to an ECC key.
+version: 1
+metadata:
+  name: matrix-oidc
+entries:
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-matrix
+    identifiers:
+      name: matrix
+    attrs:
+      client_type: confidential
+      client_id: uJXPSHb3y6CVGcdzy5g0LtNgQ3COZHJOFDjnw8Il
+      sub_mode: user_username
+      include_claims_in_id_token: true
+      issuer_mode: per_provider
+      grant_types:
+        - authorization_code
+        - refresh_token
+      redirect_uris:
+        - matching_mode: strict
+          url: https://mas.thegeekybits.com/upstream/callback/01K0AH2QJ4E8SNVGW5T7D9F3RB
+      authorization_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      signing_key:
+        !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-email"]]
+
+  - model: authentik_core.application
+    id: app-matrix
+    identifiers:
+      slug: matrix
+    attrs:
+      name: Matrix
+      provider: !KeyOf provider-matrix
+      policy_engine_mode: any

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
     files:
       - blueprints/setup-passkey.yaml
       - blueprints/headlamp-oidc.yaml
+      - blueprints/matrix-oidc.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/tools/db-backup/app/cronjob-mas.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-mas.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-mas
+spec:
+  schedule: "58 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: mas-secret
+                      key: db_password
+                - name: PGHOST
+                  value: mas-postgres.tools.svc.cluster.local
+                - name: PGUSER
+                  value: mas
+                - name: PGDATABASE
+                  value: mas
+                - name: RETENTION_DAYS
+                  value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/mas-${TS}.dump"
+                  echo "[$(date -u)] pg_dump mas -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning mas-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'mas-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/cronjob-synapse.yaml
+++ b/kubernetes/apps/tools/db-backup/app/cronjob-synapse.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-synapse
+spec:
+  schedule: "55 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: synapse-secret
+                      key: db_password
+                - name: PGHOST
+                  value: synapse-postgres.tools.svc.cluster.local
+                - name: PGUSER
+                  value: synapse
+                - name: PGDATABASE
+                  value: synapse
+                - name: RETENTION_DAYS
+                  value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT="/backups/synapse-${TS}.dump"
+                  echo "[$(date -u)] pg_dump synapse -> ${OUT}"
+                  pg_dump --no-owner --no-privileges --format=custom --compress=9 --file="${OUT}"
+                  ls -lh "${OUT}"
+                  echo "Pruning synapse-*.dump older than ${RETENTION_DAYS}d"
+                  find /backups -name 'synapse-*.dump' -type f -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/tools/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/tools/db-backup/app/kustomization.yaml
@@ -6,7 +6,9 @@ resources:
   - ./rbac.yaml
   - ./cronjob-atuin.yaml
   - ./cronjob-forgejo.yaml
+  - ./cronjob-mas.yaml
   - ./cronjob-mattermost.yaml
   - ./cronjob-nextcloud.yaml
   - ./cronjob-shlink.yaml
+  - ./cronjob-synapse.yaml
   - ./cronjob-zipline.yaml

--- a/kubernetes/apps/tools/element/app/configmap.yaml
+++ b/kubernetes/apps/tools/element/app/configmap.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: element-config
+data:
+  # Element Web is pinned to this homeserver: base_url points at the Synapse
+  # client API host; server_name is the Matrix server_name (user IDs).
+  # Custom homeserver URLs and guests are disabled — this is a single-server,
+  # internal-only deployment.
+  config.json: |
+    {
+      "default_server_config": {
+        "m.homeserver": {
+          "base_url": "https://synapse.${SECRET_DOMAIN}",
+          "server_name": "matrix.${SECRET_DOMAIN}"
+        }
+      },
+      "disable_custom_urls": true,
+      "disable_guests": true,
+      "default_theme": "dark",
+      "room_directory": {
+        "servers": []
+      },
+      "show_labs_settings": false
+    }

--- a/kubernetes/apps/tools/element/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/element/app/helmrelease.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: element
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: element
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/element-hq/element-web
+              tag: v1.12.23
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            # The upstream element-web image runs nginx as root (master binds
+            # :80, workers drop to nginx) — the 65534 default does not apply.
+            securityContext:
+              allowPrivilegeEscalation: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        controller: main
+        ports:
+          http:
+            port: 80
+
+    persistence:
+      config:
+        type: configMap
+        name: element-config
+        globalMounts:
+          - path: /app/config.json
+            subPath: config.json
+            readOnly: true
+
+    route:
+      app:
+        hostnames: ["matrix.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          # /.well-known/matrix/* on this host is served by Synapse via its own
+          # "wellknown" route (more-specific path wins at the gateway).
+          - backendRefs:
+              - name: element
+                port: 80

--- a/kubernetes/apps/tools/element/app/kustomization.yaml
+++ b/kubernetes/apps/tools/element/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tools/element/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/element/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: element
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/element/ks.yaml
+++ b/kubernetes/apps/tools/element/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: element
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/element/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -23,5 +23,8 @@ resources:
   - ./webtop/ks.yaml
   - ./nextcloud/ks.yaml
   - ./mattermost/ks.yaml
+  - ./synapse/ks.yaml
+  - ./mas/ks.yaml
+  - ./element/ks.yaml
   # - ./syncthing/ks.yaml
   # - ./kms/ks.yaml ## Disabling for now, likely to archive later

--- a/kubernetes/apps/tools/mas/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/mas/app/externalsecret.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mas
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: mas-secret
+    template:
+      engineVersion: v2
+      data:
+        db_password: "{{ .db_password }}"
+        # Full MAS config rendered here (holds the encryption secret, signing
+        # key, and OIDC client secret, so no ConfigMap). Login is SSO-only:
+        # passwords disabled, Authentik is the sole upstream provider. The
+        # upstream provider id is a pinned ULID — Authentik's redirect URI
+        # (blueprint matrix-oidc.yaml) embeds it and must match byte-exactly.
+        # secrets.encryption cannot be changed after first startup.
+        config.yaml: |
+          http:
+            public_base: "https://mas.${SECRET_DOMAIN}/"
+            listeners:
+              - name: web
+                resources:
+                  - name: discovery
+                  - name: human
+                  - name: oauth
+                  - name: compat
+                  - name: graphql
+                  - name: assets
+                    path: /usr/local/share/mas-cli/assets/
+                binds:
+                  - address: "[::]:8080"
+              - name: internal
+                resources:
+                  - name: health
+                binds:
+                  - address: "[::]:8081"
+          database:
+            uri: "postgresql://mas:{{ .db_password }}@mas-postgres:5432/mas?sslmode=disable"
+          secrets:
+            encryption: "{{ .encryption_secret }}"
+            keys:
+              - kid: rsa1
+                key: |{{ .rsa_private_key | nindent 18 }}
+          matrix:
+            kind: synapse
+            homeserver: "matrix.${SECRET_DOMAIN}"
+            endpoint: "http://synapse-main.tools.svc.cluster.local:8008/"
+            secret: "{{ .mas_shared_secret }}"
+          passwords:
+            enabled: false
+          account:
+            password_registration_enabled: false
+            email_change_allowed: false
+            displayname_change_allowed: true
+          upstream_oauth2:
+            providers:
+              - id: 01K0AH2QJ4E8SNVGW5T7D9F3RB
+                human_name: Authentik
+                issuer: "https://auth.${SECRET_DOMAIN}/application/o/matrix/"
+                client_id: "uJXPSHb3y6CVGcdzy5g0LtNgQ3COZHJOFDjnw8Il"
+                client_secret: "{{ .authentik_client_secret }}"
+                token_endpoint_auth_method: client_secret_basic
+                scope: "openid profile email"
+                claims_imports:
+                  localpart:
+                    action: require
+                    template: "{{ `{{ user.preferred_username }}` }}"
+                  displayname:
+                    action: suggest
+                    template: "{{ `{{ user.name }}` }}"
+                  email:
+                    action: suggest
+                    template: "{{ `{{ user.email }}` }}"
+  data:
+    - secretKey: db_password
+      remoteRef:
+        key: mas
+        property: db_password
+    - secretKey: encryption_secret
+      remoteRef:
+        key: mas
+        property: encryption_secret
+    - secretKey: rsa_private_key
+      remoteRef:
+        key: mas
+        property: rsa_private_key
+    - secretKey: authentik_client_secret
+      remoteRef:
+        key: mas
+        property: authentik_client_secret
+    # Shared with Synapse — single source of truth is the `synapse` 1P item.
+    - secretKey: mas_shared_secret
+      remoteRef:
+        key: synapse
+        property: mas_shared_secret

--- a/kubernetes/apps/tools/mas/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mas/app/helmrelease.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mas
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: mas
+  interval: 1h
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/element-hq/matrix-authentication-service
+              tag: 1.20.0
+            args:
+              - server
+              - --config
+              - /config/config.yaml
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
+
+      postgres:
+        strategy: Recreate
+        containers:
+          postgres:
+            image:
+              repository: postgres
+              tag: 18-alpine
+            env:
+              POSTGRES_DB: mas
+              POSTGRES_USER: mas
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: mas-secret
+                    key: db_password
+              PGDATA: /var/lib/postgresql/data/pgdata
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+        pod:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8080
+      postgres:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+
+    persistence:
+      postgres-data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        advancedMounts:
+          postgres:
+            postgres:
+              - path: /var/lib/postgresql/data
+      config:
+        type: secret
+        name: mas-secret
+        advancedMounts:
+          main:
+            app:
+              - path: /config/config.yaml
+                subPath: config.yaml
+                readOnly: true
+
+    route:
+      app:
+        hostnames: ["mas.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: mas-main
+                port: 8080

--- a/kubernetes/apps/tools/mas/app/kustomization.yaml
+++ b/kubernetes/apps/tools/mas/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tools/mas/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/mas/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mas
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/mas/ks.yaml
+++ b/kubernetes/apps/tools/mas/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mas
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/mas/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/synapse/app/configmap.yaml
+++ b/kubernetes/apps/tools/synapse/app/configmap.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: synapse-log-config
+data:
+  log.config: |
+    version: 1
+    formatters:
+      precise:
+        format: '%(asctime)s - %(name)s - %(lineno)d - %(levelname)s - %(request)s - %(message)s'
+    handlers:
+      console:
+        class: logging.StreamHandler
+        formatter: precise
+    loggers:
+      synapse.storage.SQL:
+        level: INFO
+    root:
+      level: INFO
+      handlers: [console]
+    disable_existing_loggers: false

--- a/kubernetes/apps/tools/synapse/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/synapse/app/externalsecret.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: synapse
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: synapse-secret
+    template:
+      engineVersion: v2
+      data:
+        db_password: "{{ .db_password }}"
+        # Full homeserver.yaml rendered here so secret material never lands in a
+        # ConfigMap. server_name is matrix.<domain> (permanent — baked into every
+        # user ID); the client API is served on synapse.<domain>. Federation is
+        # fully disabled (no federation listener + empty domain whitelist).
+        # Auth is delegated to MAS (matrix_authentication_service block) — the
+        # stable replacement for experimental_features.msc3861; requires
+        # Synapse >= 1.136.
+        homeserver.yaml: |
+          server_name: "matrix.${SECRET_DOMAIN}"
+          public_baseurl: "https://synapse.${SECRET_DOMAIN}/"
+          serve_client_wellknown: true
+          report_stats: false
+          pid_file: /tmp/homeserver.pid
+          media_store_path: /data/media
+          signing_key_path: /data/keys/signing.key
+          log_config: /data/log.config
+          max_upload_size: 100M
+          enable_registration: false
+          federation_domain_whitelist: []
+          trusted_key_servers: []
+          suppress_key_server_warning: true
+          listeners:
+            - port: 8008
+              tls: false
+              type: http
+              x_forwarded: true
+              bind_addresses: ['0.0.0.0']
+              resources:
+                - names: [client]
+                  compress: false
+          database:
+            name: psycopg2
+            args:
+              user: synapse
+              password: "{{ .db_password }}"
+              database: synapse
+              host: synapse-postgres
+              port: 5432
+              cp_min: 5
+              cp_max: 10
+          registration_shared_secret: "{{ .registration_shared_secret }}"
+          macaroon_secret_key: "{{ .macaroon_secret_key }}"
+          form_secret: "{{ .form_secret }}"
+          matrix_authentication_service:
+            enabled: true
+            endpoint: http://mas-main.tools.svc.cluster.local:8080/
+            secret: "{{ .mas_shared_secret }}"
+  dataFrom:
+    - extract:
+        key: synapse

--- a/kubernetes/apps/tools/synapse/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/synapse/app/helmrelease.yaml
@@ -1,0 +1,193 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: synapse
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: synapse
+  interval: 1h
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Synapse does not auto-generate its ed25519 signing key when running
+          # from a mounted config; generate once onto the data PVC.
+          init-keys:
+            image:
+              repository: ghcr.io/element-hq/synapse
+              tag: v1.156.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                test -f /data/keys/signing.key || /usr/local/bin/generate_signing_key -o /data/keys/signing.key
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+        containers:
+          app:
+            image:
+              repository: ghcr.io/element-hq/synapse
+              tag: v1.156.0
+            env:
+              SYNAPSE_CONFIG_PATH: /data/homeserver.yaml
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8008
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8008
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 250m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            fsGroupChangePolicy: OnRootMismatch
+
+      postgres:
+        strategy: Recreate
+        containers:
+          postgres:
+            image:
+              repository: postgres
+              tag: 18-alpine
+            env:
+              POSTGRES_DB: synapse
+              POSTGRES_USER: synapse
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: synapse-secret
+                    key: db_password
+              # Synapse requires a C-locale database (LC_COLLATE/LC_CTYPE=C).
+              POSTGRES_INITDB_ARGS: "--encoding=UTF8 --lc-collate=C --lc-ctype=C"
+              PGDATA: /var/lib/postgresql/data/pgdata
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+        pod:
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            fsGroup: 999
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: 8008
+      postgres:
+        controller: postgres
+        ports:
+          postgres:
+            port: 5432
+
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 20Gi
+        advancedMounts:
+          main:
+            app:
+              - path: /data/media
+                subPath: media
+              - path: /data/keys
+                subPath: keys
+            init-keys:
+              - path: /data/keys
+                subPath: keys
+      postgres-data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        advancedMounts:
+          postgres:
+            postgres:
+              - path: /var/lib/postgresql/data
+      config:
+        type: secret
+        name: synapse-secret
+        advancedMounts:
+          main:
+            app:
+              - path: /data/homeserver.yaml
+                subPath: homeserver.yaml
+                readOnly: true
+      log-config:
+        type: configMap
+        name: synapse-log-config
+        advancedMounts:
+          main:
+            app:
+              - path: /data/log.config
+                subPath: log.config
+                readOnly: true
+
+    route:
+      app:
+        hostnames: ["synapse.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: synapse-main
+                port: 8008
+      # Serve /.well-known/matrix/* on the server_name host (matrix.<domain>,
+      # otherwise Element Web's host) so clients discover the client API and
+      # MAS. More-specific path beats Element's catch-all at the gateway.
+      wellknown:
+        hostnames: ["matrix.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /.well-known/matrix
+            backendRefs:
+              - name: synapse-main
+                port: 8008

--- a/kubernetes/apps/tools/synapse/app/kustomization.yaml
+++ b/kubernetes/apps/tools/synapse/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tools/synapse/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/synapse/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: synapse
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/synapse/ks.yaml
+++ b/kubernetes/apps/tools/synapse/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: synapse
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/tools/synapse/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false


### PR DESCRIPTION
Deploys the Matrix stack to the `tools` namespace, internal-only (`envoy-internal`), replacing nothing yet — Mattermost stays live.

## Components
- **Synapse v1.156.0** — `synapse.<domain>`, postgres:18 sidecar (C-locale init), federation disabled, homeserver.yaml rendered by ESO from the 1P `synapse` item. `server_name` = `matrix.<domain>` (permanent). Signing key generated once by an init container onto the data PVC. Auth delegated to MAS via the stable `matrix_authentication_service` block (Synapse ≥1.136).
- **MAS 1.20.0** — `mas.<domain>`, postgres sidecar, passwords disabled; Authentik is the sole upstream OIDC provider (pinned client_id, pinned provider ULID in the redirect URI). Config rendered by ESO from the 1P `mas` item; MAS↔Synapse shared secret sourced from the `synapse` item (single source of truth).
- **Element Web v1.12.23** — `matrix.<domain>`, pinned to this homeserver, guests/custom URLs disabled. `/.well-known/matrix/*` on that host routes to Synapse (`serve_client_wellknown`) via a more-specific-path HTTPRoute.
- **Authentik blueprint** `matrix-oidc.yaml` — provider + app codified (no click-ops), RSA signing key, `user_username` sub_mode; client_secret omitted per house convention (read out post-apply → 1P `mas.authentik_client_secret`).
- **db-backup** — nightly pg_dump cronjobs for both DBs.
- **Docs/monitoring** — auth matrix rows (internal / `native_oidc`), deployment-plan session log, Gatus endpoints.

## Validation
- flux-local test: **144 passed**
- routes, secret-keys, yamllint, substitutions: ✅
- validate:secrets: pending 1P item creation (`synapse`, `mas`) — **merge gate**
- Image tags verified directly against ghcr (the local validate:images 404s are rate-limiting noise; it 404s sonarr/plex too)

## Post-merge steps
1. Read Authentik-generated client secret for provider `matrix` → 1P `mas.authentik_client_secret`
2. SSO login test (Element → MAS → Authentik)
3. PR2: Hermes `MATTERMOST_*` → `MATRIX_*` cutover + DM validation

https://claude.ai/code/session_01M4vNyshmi8kVARr15k2Ny1