### PR TITLE
feat(hermes): cut over gateway from Mattermost to Matrix

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -19,27 +19,31 @@ spec:
         # still deferred — add fields to the hermes-dotenv 1Password item and
         # reference them here when enabling.
         #
-        # Mattermost is wired: the gateway auto-enables the bundled Mattermost
-        # platform adapter purely from MATTERMOST_URL/MATTERMOST_TOKEN
-        # presence (no HelmRelease/config.yaml change needed). Bot account
-        # "hermes" lives in the mixos team; access is open to any user in
-        # this (internal-only) instance; MATTERMOST_HOME_CHANNEL points at
-        # the dedicated #hermes-home channel for cron/proactive delivery.
-        # MATTERMOST_REPLY_MODE=thread keeps @mention/channel replies in the
-        # originating thread instead of posting new root messages.
+        # Matrix cutover (2026-07-17, replaces the Mattermost adapter): the
+        # gateway auto-enables the bundled Matrix platform adapter from
+        # MATRIX_HOMESERVER/MATRIX_ACCESS_TOKEN presence. Bot @hermes lives on
+        # the internal Synapse (auth delegated to MAS; token is a MAS
+        # compatibility token). Access is allowlisted to Shawn instead of the
+        # old allow-all; MATRIX_HOME_ROOM is the private #hermes-home room for
+        # cron/proactive delivery. SESSION_SCOPE=room isolates context per
+        # room; AUTO_THREAD replaces Mattermost's REPLY_MODE=thread. E2EE off:
+        # internal-only traffic, plain HTTP inside the cluster.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
-          MATTERMOST_URL=http://mattermost-main.tools.svc.cluster.local:8065
-          MATTERMOST_TOKEN={{ .MATTERMOST_TOKEN }}
-          MATTERMOST_ALLOW_ALL_USERS=true
-          MATTERMOST_HOME_CHANNEL=4qkyyzxfejdtuqpdkkiatbemur
-          MATTERMOST_REPLY_MODE=thread
+          MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
+          MATRIX_ACCESS_TOKEN={{ .MATRIX_ACCESS_TOKEN }}
+          MATRIX_USER_ID=@hermes:matrix.thegeekybits.com
+          MATRIX_ALLOWED_USERS=@shawnmix:matrix.thegeekybits.com
+          MATRIX_HOME_ROOM=!ntkctnHmoGmUeEqHMQ:matrix.thegeekybits.com
+          MATRIX_SESSION_SCOPE=room
+          MATRIX_AUTO_THREAD=true
+          MATRIX_E2EE_MODE=off
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:
         key: hermes-dotenv
         property: password
-    - secretKey: MATTERMOST_TOKEN
+    - secretKey: MATRIX_ACCESS_TOKEN
       remoteRef:
         key: hermes-dotenv
-        property: MATTERMOST_TOKEN
+        property: MATRIX_ACCESS_TOKEN


### PR DESCRIPTION
Swaps hermes-agent's platform adapter env from `MATTERMOST_*` to `MATRIX_*` (adapter auto-enables from env presence — no HelmRelease change).

- Bot: `@hermes` on the internal Synapse (PR #378), MAS compatibility token from 1P `hermes-dotenv.MATRIX_ACCESS_TOKEN` (verified via whoami)
- `MATRIX_ALLOWED_USERS` allowlists Shawn (replaces the old allow-all)
- `MATRIX_HOME_ROOM` = private `hermes-home` room (already created, bot is member)
- `MATRIX_SESSION_SCOPE=room`, `MATRIX_AUTO_THREAD=true` (replaces `MATTERMOST_REPLY_MODE=thread`)
- E2EE off — internal-only, in-cluster HTTP
- Mattermost server stays deployed; only hermes moves

Validation: flux-local test 144 passed, yamllint clean.
Post-merge: reloader restarts hermes; validate with a DM round-trip.

https://claude.ai/code/session_01M4vNyshmi8kVARr15k2Ny1