### PR TITLE
fix(headlamp): use access_token for OIDC to stop login hang

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -26,11 +26,25 @@ spec:
               # (HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL -> -oidc-idp-issuer-url).
               # Bare OIDC_* names are silently ignored.
               HEADLAMP_CONFIG_OIDC_IDP_ISSUER_URL: https://auth.${SECRET_DOMAIN}/application/o/headlamp/
-              # offline_access is required: Headlamp refreshes the id_token on
+              # offline_access is required: Headlamp refreshes the token on
               # every API call and hard-fails login ("refreshing token: getting
               # refresh token: key not found") if the IdP issued no refresh
               # token. authentik only returns one when offline_access is granted.
               HEADLAMP_CONFIG_OIDC_SCOPES: openid,email,profile,offline_access
+              # Use the access_token (not the id_token) as the bearer + the key
+              # for Headlamp's in-memory refresh-token cache. Headlamp stores the
+              # refresh token at login keyed by the raw user token, then looks it
+              # up on every API-call refresh. With the id_token (default) the
+              # store-key and the bearer the SPA replays don't stay byte-identical,
+              # so the very first refresh misses -> "getting refresh token: key
+              # not found" -> login hangs at "Redirecting to main page...".
+              # Keying on the access_token keeps both sides consistent.
+              # SAFE for the apiserver: authentik's JWT access_token carries the
+              # same iss + aud(=oidc-client-id) + email/email_verified/groups
+              # claims the kube-apiserver validates (verified against the live
+              # token), so forwarded-token auth is unchanged.
+              # headlamp-k8s/headlamp#4134, #4122.
+              HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN: "true"
             envFrom:
               - secretRef:
                   name: headlamp-secret


### PR DESCRIPTION
## Problem
Headlamp SSO via Authentik completed auth but hung at `Redirecting to main page...` and never reached the dashboard. Backend pod logged on every login:
```
refreshing token: getting refresh token: key not found → failed to refresh token
```

## Diagnosis
- **Authentik side is correct** — verified 2 non-revoked `RefreshToken` rows issued to shawnmix with `offline_access` scope at the exact login timestamps; provider matches the blueprint (confidential, strict `/oidc-callback`, offline_access mapped).
- **Fault is Headlamp-side.** Headlamp refreshes the token on *every* API call and keys its in-memory refresh-token cache by the raw user token. With the default **id_token**, the key stored at login and the bearer the SPA replays aren't byte-identical, so the very first post-login refresh misses → `key not found` → login hangs. Known upstream: headlamp-k8s/headlamp#4134, #4122.

## Fix
Set `HEADLAMP_CONFIG_OIDC_USE_ACCESS_TOKEN=true` so Headlamp keys on and forwards the **access_token** consistently.

**Verified safe for the kube-apiserver:** decoded the live Authentik access_token — it carries the same claims the apiserver validates:
| apiserver check | access_token value |
|---|---|
| `oidc-issuer-url` | `https://auth.example.com/application/o/headlamp/` ✓ |
| `oidc-client-id` (aud) | `WxrKDa2...` ✓ |
| `oidc-username-claim: email` | `shawnmix@gmail.com` (email_verified: true) ✓ |
| `oidc-groups-claim: groups` | `[tier1, authentik Admins]` ✓ |

So forwarded-token auth to the apiserver is unchanged.

## Test after merge
Flux deploys on merge → hard-refresh `headlamp.example.com` → Sign In → should land on the dashboard. Confirm no new `key not found` in `kubectl -n monitoring logs deploy/headlamp`.

https://claude.ai/code/session_01LqDya3WRkz8Sy1RcgMpozP
