### PR TITLE
fix(headlamp): recover Safari OIDC login via opener-side plugin

### DIFF
--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -96,3 +96,62 @@ spec:
           - backendRefs:
               - name: headlamp
                 port: 4466
+
+    persistence:
+      # Mount the safari-oidc-fix plugin into Headlamp's -plugins-dir. The whole
+      # ConfigMap is mounted as a directory (no subPath) so both main.js and
+      # package.json land in the plugin folder; Headlamp discovers/serves the
+      # ConfigMap's symlinked files fine. The chart stamps a checksum/configMaps
+      # pod annotation, so editing the JS below rolls the pod automatically and the
+      # new plugin is picked up at startup (in-cluster live watching stays off).
+      plugin:
+        type: configMap
+        identifier: plugin
+        globalMounts:
+          - path: /headlamp/plugins/safari-oidc-fix
+            readOnly: true
+
+    configMaps:
+      # Safari-only OIDC login fix. Headlamp runs login in a popup that writes
+      # localStorage 'auth_status'='success' and closes; the opener leaves /login
+      # on a cross-window 'storage' event, which Safari drops — so login hangs on
+      # /c/<cluster>/login even though the token is already stored (Chrome works).
+      # No Headlamp flag/version/header fixes this; this opener-side plugin re-checks
+      # on focus/visibility/poll (all fire reliably in Safari after the popup closes)
+      # and navigates off /login. The devDependencies pin is LOAD-BEARING: the
+      # frontend's isCompatible gate (>=0.8.0-alpha.3) silently drops the plugin
+      # without it. Plain IIFE, no @kinvolk/headlamp-plugin build step.
+      plugin:
+        data:
+          package.json: |
+            {
+              "name": "safari-oidc-fix",
+              "version": "1.0.0",
+              "description": "Recover OIDC login navigation on Safari after the auth popup closes",
+              "devDependencies": {
+                "@kinvolk/headlamp-plugin": "^0.13.0"
+              }
+            }
+          main.js: |
+            // Headlamp Safari OIDC login recovery (side-effect-only, no build step).
+            // The OIDC popup writes localStorage 'auth_status'='success' and closes; the
+            // opener is supposed to leave /login on a cross-window 'storage' event, which
+            // Safari drops. This runs in the opener and recovers by navigating off /login
+            // once the token is present — the same effect as manually stripping /login.
+            (function () {
+              'use strict';
+              function recover() {
+                try {
+                  if (localStorage.getItem('auth_status') !== 'success') return;
+                  var path = window.location.pathname;
+                  if (!/\/login$/.test(path)) return;
+                  localStorage.removeItem('auth_status');
+                  window.location.assign(path.replace(/\/login$/, '') || '/');
+                } catch (e) { /* no-op */ }
+              }
+              window.addEventListener('focus', recover);
+              document.addEventListener('visibilitychange', function () {
+                if (document.visibilityState === 'visible') recover();
+              });
+              setInterval(recover, 1000);
+            })();

--- a/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/headlamp/app/helmrelease.yaml
@@ -138,11 +138,15 @@ spec:
             // opener is supposed to leave /login on a cross-window 'storage' event, which
             // Safari drops. This runs in the opener and recovers by navigating off /login
             // once the token is present — the same effect as manually stripping /login.
+            // Polls localStorage (independent of Safari's flaky cross-window storage
+            // event) so it recovers whether or not focus/visibility fire. Loaded at
+            // app bootstrap above the auth boundary, so it runs while stuck on /login.
             (function () {
               'use strict';
               function recover() {
                 try {
-                  if (localStorage.getItem('auth_status') !== 'success') return;
+                  // truthy, not === 'success', to stay robust if the value ever changes
+                  if (!localStorage.getItem('auth_status')) return;
                   var path = window.location.pathname;
                   if (!/\/login$/.test(path)) return;
                   localStorage.removeItem('auth_status');
@@ -153,5 +157,6 @@ spec:
               document.addEventListener('visibilitychange', function () {
                 if (document.visibilityState === 'visible') recover();
               });
-              setInterval(recover, 1000);
+              setInterval(recover, 750);
+              recover(); // in case auth_status is already set when this loads
             })();


### PR DESCRIPTION
## Problem
After #381 (access_token fix), **Chrome login works but Safari still hangs** on `/c/main/login` after the OIDC popup closes. Removing `/login` from the URL manually loads the dashboard — proving the token is already stored and only the cross-window redirect is lost.

## Root cause (Headlamp front end, confirmed against v0.43.0 source)
Login runs in a **popup**. The popup's callback page writes `localStorage.setItem('auth_status','success')` and closes; the **opener** is supposed to leave `/login` on a cross-window `storage` event (`OauthPopup.tsx`). **Safari drops that event** — WebKit delivers cross-window `storage` to a popup opener unreliably, and Headlamp's own popup `beforeunload` handler tears down the opener's listener first. No `postMessage`/`window.opener` is used, so nothing recovers it. **No Headlamp flag, version, or header fixes this** (still broken on `main`; COOP is not involved — no such header is set).

## Fix
A tiny **opener-side plugin** dropped into Headlamp's (empty) `-plugins-dir` via a ConfigMap mount. It re-checks `auth_status` on `focus`/`visibilitychange`/1s poll — all of which fire reliably in Safari once the popup closes — and navigates off `/login`, i.e. automates the manual URL fix.

- Plain IIFE, **no build step**, no `@kinvolk/headlamp-plugin` import.
- `package.json` carries the **load-bearing** `devDependencies['@kinvolk/headlamp-plugin']` pin — without it Headlamp's frontend `isCompatible` gate (`>=0.8.0-alpha.3`) silently drops the plugin.
- No-ops in Chrome (native handler clears `auth_status` first; the `/login$` guard then bails).

## Validation
Rendered the values through `app-template` 5.0.1: produces the `ConfigMap` (`main.js` + `package.json`), the `volumeMount` at `/headlamp/plugins/safari-oidc-fix`, and a `checksum/configMaps` pod annotation (so the pod rolls on deploy and on any future JS edit). Source confirms `os.Stat`/`http.FileServer` follow the ConfigMap symlinks, so discovery/serving work.

## Test after merge
Flux deploys → pod rolls → in **Safari**, hard-refresh `headlamp.example.com`, Sign In, complete Authentik in the popup → main window should land on the dashboard on its own. Chrome should remain unaffected.

https://claude.ai/code/session_01LqDya3WRkz8Sy1RcgMpozP
