### PR TITLE
feat(monitoring): deploy kube-prometheus-stack

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/configmap.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources-kps
+  labels:
+    grafana_datasource: "1"
+data:
+  kps-datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        uid: prometheus
+        type: prometheus
+        access: proxy
+        url: http://kps-prometheus.monitoring.svc.cluster.local:9090
+        isDefault: true
+        jsonData:
+          timeInterval: 30s
+      - name: Alertmanager
+        uid: alertmanager
+        type: alertmanager
+        access: proxy
+        url: http://kps-alertmanager.monitoring.svc.cluster.local:9093
+        jsonData:
+          implementation: prometheus
+          handleGrafanaManagedAlerts: false

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: alertmanager-secret
+    template:
+      data:
+        webhook-url: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: discord-webhook-jarvis

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: kube-prometheus-stack
+  values:
+    # CRDs are managed by the bootstrap helmfile (same chart version)
+    crds:
+      enabled: false
+    cleanPrometheusOperatorObjectNames: true
+    fullnameOverride: kps
+
+    defaultRules:
+      create: true
+      rules:
+        # Talos: controller-manager/scheduler bind to localhost; Cilium replaces kube-proxy
+        etcd: false
+        kubeControllerManager: false
+        kubeProxy: false
+        kubeSchedulerAlerting: false
+        kubeSchedulerRecording: false
+        windows: false
+
+    kubeControllerManager:
+      enabled: false
+    kubeScheduler:
+      enabled: false
+    kubeProxy:
+      enabled: false
+    kubeEtcd:
+      enabled: false
+
+    prometheusOperator:
+      resources:
+        requests:
+          cpu: 25m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+
+    prometheus:
+      prometheusSpec:
+        # Scrape every ServiceMonitor/PodMonitor/PrometheusRule/Probe/ScrapeConfig
+        # in the cluster, regardless of helm release labels
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+        scrapeConfigSelectorNilUsesHelmValues: false
+        enableAdminAPI: true
+        walCompression: true
+        retention: 14d
+        retentionSize: 25GB
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          limits:
+            memory: 2Gi
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn-nobackup
+              resources:
+                requests:
+                  storage: 30Gi
+
+    alertmanager:
+      enabled: true
+      alertmanagerSpec:
+        secrets:
+          - alertmanager-secret
+        storage:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: longhorn-nobackup
+              resources:
+                requests:
+                  storage: 1Gi
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi
+      config:
+        route:
+          group_by: ["alertname", "namespace"]
+          group_wait: 1m
+          group_interval: 10m
+          repeat_interval: 12h
+          receiver: discord
+          routes:
+            - receiver: "null"
+              matchers:
+                - alertname =~ "Watchdog|InfoInhibitor"
+        receivers:
+          - name: "null"
+          - name: discord
+            discord_configs:
+              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-secret/webhook-url
+                send_resolved: true
+                title: >-
+                  [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+
+    grafana:
+      enabled: false
+      # Ship the bundled dashboards as ConfigMaps; the existing Grafana
+      # sidecar (grafana_dashboard label, searchNamespace ALL) picks them up
+      forceDeployDashboards: true
+
+    nodeExporter:
+      enabled: true
+
+    kubeStateMetrics:
+      enabled: true

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/httproute.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: prometheus
+spec:
+  hostnames:
+    - prometheus.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: kps-prometheus
+          port: 9090
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+spec:
+  hostnames:
+    - alertmanager.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: kps-alertmanager
+          port: 9093

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./httproute.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 85.3.3
+  url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kube-prometheus-stack
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/kube-prometheus-stack/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./grafana/ks.yaml
   - ./headlamp/ks.yaml
+  - ./kube-prometheus-stack/ks.yaml


### PR DESCRIPTION
Phase 2 of the observability rollout (after #386).

- **Prometheus** 14d/25GB retention on `longhorn-nobackup` (30Gi PVC), nil selectors → scrapes every ServiceMonitor/PodMonitor/PrometheusRule cluster-wide (the dormant envoy-proxy PodMonitor + external-secrets ServiceMonitor activate immediately)
- **Alertmanager** → Discord (`discord-webhook-jarvis` via ExternalSecret, `webhook_url_file`), Watchdog/InfoInhibitor routed to null. Note: native `discord_configs` instead of Apprise — Alertmanager's webhook payload isn't Apprise-API compatible without an adapter shim; alerts still land in the same Discord channel
- **node-exporter + kube-state-metrics + default rules** (Talos-inappropriate targets disabled: etcd, controller-manager, scheduler, kube-proxy/Cilium)
- **Grafana subchart off** — reuses existing Grafana: bundled dashboards force-deployed as sidecar ConfigMaps, Prometheus/Alertmanager datasources via `grafana_datasource` ConfigMap
- Chart **85.3.3** pinned to match bootstrap CRDs (`crds.enabled: false`)
- Internal routes: `prometheus.` / `alertmanager.` — in-cluster endpoints for automations: `http://kps-prometheus.monitoring:9090`, `http://kps-alertmanager.monitoring:9093`

Validated: kustomize build + full helm template render (94 objects).

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2