### PR TITLE
fix(monitoring): alertmanager config via ExternalSecret

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
@@ -9,10 +9,33 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-store
   target:
-    name: alertmanager-secret
+    name: alertmanager-config
     template:
       data:
-        webhook-url: "{{ .password }}"
+        alertmanager.yaml: |
+          route:
+            group_by: ["alertname", "namespace"]
+            group_wait: 1m
+            group_interval: 10m
+            repeat_interval: 12h
+            receiver: discord
+            routes:
+              - receiver: "null"
+                matchers:
+                  - alertname =~ "Watchdog|InfoInhibitor"
+          receivers:
+            - name: "null"
+            - name: discord
+              discord_configs:
+                - webhook_url: "{{ .password }}"
+                  send_resolved: true
+          inhibit_rules:
+            - source_matchers: ["severity = critical"]
+              target_matchers: ["severity =~ warning|info"]
+              equal: ["alertname", "namespace"]
+            - source_matchers: ["severity = warning"]
+              target_matchers: ["severity = info"]
+              equal: ["alertname", "namespace"]
   dataFrom:
     - extract:
         key: discord-webhook-jarvis

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -74,8 +74,9 @@ spec:
     alertmanager:
       enabled: true
       alertmanagerSpec:
-        secrets:
-          - alertmanager-secret
+        # Full config rendered by the alertmanager ExternalSecret (webhook
+        # inline — the operator's parser rejects discord webhook_url_file)
+        configSecret: alertmanager-config
         storage:
           volumeClaimTemplate:
             spec:
@@ -89,26 +90,6 @@ spec:
             memory: 64Mi
           limits:
             memory: 128Mi
-      config:
-        route:
-          group_by: ["alertname", "namespace"]
-          group_wait: 1m
-          group_interval: 10m
-          repeat_interval: 12h
-          receiver: discord
-          routes:
-            - receiver: "null"
-              matchers:
-                - alertname =~ "Watchdog|InfoInhibitor"
-        receivers:
-          - name: "null"
-          - name: discord
-            discord_configs:
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-secret/webhook-url
-                send_resolved: true
-                title: >-
-                  [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
-
     grafana:
       enabled: false
       # Ship the bundled dashboards as ConfigMaps; the existing Grafana


### PR DESCRIPTION
Follow-up to #387 — the operator rejected `webhook_url_file` in `discord_configs` (StatefulSetNotFound, config unmarshal error). Full `alertmanager.yaml` is now templated by the ExternalSecret (webhook inline from `discord-webhook-jarvis`) and wired via `alertmanagerSpec.configSecret`. Also adds standard severity-tier inhibit rules.

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2