### PR TITLE
feat(monitoring): deploy loki

### DIFF
--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./grafana/ks.yaml
   - ./headlamp/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./loki/ks.yaml

--- a/kubernetes/apps/monitoring/loki/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/loki/app/configmap.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources-loki
+  labels:
+    grafana_datasource: "1"
+data:
+  loki-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        uid: loki
+        type: loki
+        access: proxy
+        url: http://loki.monitoring.svc.cluster.local:3100
+        jsonData:
+          maxLines: 1000

--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: loki
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      storage:
+        type: filesystem
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      limits_config:
+        retention_period: 14d
+      compactor:
+        working_directory: /var/loki/compactor
+        retention_enabled: true
+        delete_request_store: filesystem
+      ingester:
+        chunk_encoding: snappy
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: longhorn-nobackup
+        size: 30Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 1Gi
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    backend:
+      replicas: 0
+    gateway:
+      enabled: false
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    lokiCanary:
+      enabled: false
+    test:
+      enabled: false
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      selfMonitoring:
+        enabled: false
+        grafanaAgent:
+          installOperator: false

--- a/kubernetes/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/loki/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/monitoring/loki/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/loki/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: loki
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 7.1.0
+  url: oci://ghcr.io/grafana/helm-charts/loki

--- a/kubernetes/apps/monitoring/loki/ks.yaml
+++ b/kubernetes/apps/monitoring/loki/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: loki
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/loki/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false


### PR DESCRIPTION
Phase 3 of the observability rollout (after #387/#388).

- Loki **3.6.8** (chart 7.1.0), `SingleBinary` mode — right-sized for a 3-node cluster
- Filesystem storage, 30Gi `longhorn-nobackup` PVC, **14d retention** enforced by compactor
- TSDB v13 schema; memcached caches, canary, test, and nginx gateway disabled
- ServiceMonitor enabled (scraped by the new Prometheus)
- Grafana `Loki` datasource via sidecar ConfigMap
- In-cluster endpoint for automations/AI: `http://loki.monitoring:3100` (push: `/loki/api/v1/push`, query: `/loki/api/v1/query_range`)

Alloy ships next as the collector that feeds it. Validated with kustomize build + full helm template.

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2