### PR TITLE
feat(monitoring): deploy alloy log collector

### DIFF
--- a/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: alloy
+  values:
+    controller:
+      type: daemonset
+    serviceMonitor:
+      enabled: true
+    alloy:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+      extraEnv:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      configMap:
+        create: true
+        content: |
+          // Tail logs for every pod scheduled on this node and ship to Loki
+          discovery.kubernetes "pods" {
+            role = "pod"
+            selectors {
+              role  = "pod"
+              field = "spec.nodeName=" + sys.env("NODE_NAME")
+            }
+          }
+
+          discovery.relabel "pods" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+              target_label  = "app"
+            }
+          }
+
+          loki.source.kubernetes "pods" {
+            targets    = discovery.relabel.pods.output
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write.default {
+            endpoint {
+              url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
+            }
+          }

--- a/kubernetes/apps/monitoring/alloy/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitoring/alloy/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: alloy
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.10.1
+  url: oci://ghcr.io/home-operations/charts-mirror/alloy

--- a/kubernetes/apps/monitoring/alloy/ks.yaml
+++ b/kubernetes/apps/monitoring/alloy/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: alloy
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/alloy/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./headlamp/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  - ./alloy/ks.yaml


### PR DESCRIPTION
Phase 4 of the observability rollout (after #389).

- **Alloy 1.17.1** (chart 1.10.1 via home-operations charts-mirror — grafana doesn't publish alloy to their ghcr OCI repo) as a DaemonSet
- Per-node log tailing via `loki.source.kubernetes` + `spec.nodeName` field selector (no hostPath mounts); labels: `namespace, pod, container, node, app`
- Pushes to `http://loki.monitoring:3100`; ServiceMonitor enabled so Prometheus watches the collector itself
- Not included (deliberate): k8s event collection — would duplicate ×3 on a DaemonSet; can add a singleton later if wanted

Every pod's logs become queryable in Grafana (Loki datasource) once this reconciles. Validated with kustomize build + helm template.

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2