### PR TITLE
fix(monitoring): alloy loki.write block label syntax

### DIFF
--- a/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
@@ -68,7 +68,7 @@ spec:
             forward_to = [loki.write.default.receiver]
           }
 
-          loki.write.default {
+          loki.write "default" {
             endpoint {
               url = "http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push"
             }


### PR DESCRIPTION
Follow-up to #390 — `loki.write.default {}` isn't valid River; the label must be quoted: `loki.write "default" {}`. Pods were CrashLooping on config load.

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2