### PR TITLE
feat(images): pin mutable image tags to semver (P1)

### DIFF
--- a/kubernetes/apps/storage/csi-driver-nfs/app/ocirepository.yaml
+++ b/kubernetes/apps/storage/csi-driver-nfs/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    semver: ">=4.0.0 <5.0.0"
+    tag: 4.13.4
   url: oci://ghcr.io/home-operations/charts-mirror/csi-driver-nfs

--- a/kubernetes/apps/tools/webtop/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/webtop/app/helmrelease.yaml
@@ -15,7 +15,7 @@ spec:
           app:
             image:
               repository: ghcr.io/linuxserver/webtop
-              tag: ubuntu-xfce
+              tag: ubuntu-xfce-afda9145-ls13
             env:
               PUID: "1000"
               PGID: "1000"

--- a/kubernetes/apps/tools/zipline/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/zipline/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
           app:
             image:
               repository: ghcr.io/diced/zipline
-              tag: v4
+              tag: "4.4.2"
             env:
               TZ: America/New_York
             envFrom:


### PR DESCRIPTION
Fixes the **P1 mutable image tags** item from the home-ops standardization backlog. Per `docs/architecture/deployment-standards.md`: semver-pinned tags only, never `latest`/`main`/channel tags; every OCIRepository must pin a `tag:`.

## Changes
| App | Before | After | Notes |
|---|---|---|---|
| webtop | `ubuntu-xfce` | `ubuntu-xfce-afda9145-ls13` | latest LinuxServer build; Renovate-trackable |
| zipline | `v4` | `4.4.2` | latest v4 release |
| csi-driver-nfs (OCIRepository) | `semver ">=4.0.0 <5.0.0"` | `tag: 4.13.4` | matches deployed chart; removes floating ref |

`hermes-agent` was already pinned (`v2026.7.7`). **litellm** is handled separately in #395 (removed entirely), so its pin was dropped from this PR.

## Validation
- `yq` parse clean; `validate-images.sh` ✓ for webtop + zipline.
- csi-driver-nfs `4.13.4` confirmed as the currently-deployed chart version. Mirror only carries 4.x (4.11.0–4.13.4); no 5.x exists, so the old `<5.0.0` guard was a plain major-pin, not an incident workaround.

## Out of scope / flagged
`open-webui` also runs a mutable `tag: main` (live) — not in the P1 list, stateful (DB migrations), latest `v0.6.18`. Recommend a separate deliberate PR.