### PR TITLE
fix(hermes-agent): put hermes CLI on container PATH

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -26,6 +26,10 @@ spec:
             args: ["gateway", "run"]
             env:
               HERMES_HOME: /opt/data
+              # The hermes CLI ships in the image venv (/opt/hermes/.venv/bin) but
+              # that dir is not on the image's default PATH, so the agent's own
+              # shell-outs to `hermes ...` fail with "hermes: not found". Prepend it.
+              PATH: /opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
               PLAYWRIGHT_BROWSERS_PATH: /opt/data/.playwright
               PYTHONUNBUFFERED: "1"
               API_SERVER_ENABLED: "true"
@@ -44,6 +48,8 @@ spec:
             args: ["dashboard", "--host", "0.0.0.0", "--no-open", "--insecure"]
             env:
               HERMES_HOME: /opt/data
+              # Keep the hermes CLI on PATH here too (see gateway container note).
+              PATH: /opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             probes:
               liveness: &probes
                 enabled: true


### PR DESCRIPTION
## Problem
The Hermes agent shells out to `hermes ...` for its own operations, but those calls fail with `hermes: not found`. The CLI ships in the image at `/opt/hermes/.venv/bin/hermes`, which is **not** on the container's default PATH (`/opt/data/.local/bin:/usr/local/sbin:...`).

Verified in the running pod:
- `/opt/hermes/.venv/bin/hermes --version` → works (v0.14.0)
- `hermes --version` via shell → `hermes: not found`

## Fix
Prepend `/opt/hermes/.venv/bin` to `PATH` on both the `gateway` and `dashboard` containers so the agent's shell-outs resolve.

## Note (out of scope)
Running pod is `v2026.5.16` while this manifest pins `v2026.7.7` — the newer tag hasn't rolled out. Flagging separately.

https://claude.ai/code/session_012gtMPfjoja5wgcUUNAHQn8