### PR TITLE
feat(monitoring): deploy uptime-kuma

### DIFF
--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
   - ./alloy/ks.yaml
+  - ./uptime-kuma/ks.yaml

--- a/kubernetes/apps/monitoring/uptime-kuma/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/uptime-kuma/app/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: uptime-kuma
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: uptime-kuma
+  interval: 1h
+  values:
+    controllers:
+      uptime-kuma:
+        containers:
+          app:
+            image:
+              repository: docker.io/louislam/uptime-kuma
+              tag: 2.4.0
+            env:
+              TZ: America/New_York
+              UPTIME_KUMA_PORT: "3001"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3001
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 2
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: uptime-kuma
+        ports:
+          http:
+            port: 3001
+    persistence:
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 4Gi
+        globalMounts:
+          - path: /app/data
+    route:
+      app:
+        hostnames: ["uptime.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https

--- a/kubernetes/apps/monitoring/uptime-kuma/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/uptime-kuma/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/monitoring/uptime-kuma/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/uptime-kuma/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: uptime-kuma
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/monitoring/uptime-kuma/ks.yaml
+++ b/kubernetes/apps/monitoring/uptime-kuma/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: uptime-kuma
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/uptime-kuma/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/tools/homepage/app/configmap.yaml
+++ b/kubernetes/apps/tools/homepage/app/configmap.yaml
@@ -146,6 +146,10 @@ data:
             href: https://teslamate.${SECRET_DOMAIN}
             description: Tesla Tracking
     - Infrastructure:
+        - Uptime Kuma:
+            icon: uptime-kuma.svg
+            href: https://uptime.${SECRET_DOMAIN}
+            description: Uptime Monitoring
         - Grafana:
             icon: grafana.svg
             href: https://grafana.${SECRET_DOMAIN}


### PR DESCRIPTION
Phase 5 of the observability rollout — the Gatus replacement.

- **Uptime Kuma 2.4.0** (v2 stable) via bjw-s app-template 5.0.1
- 4Gi `longhorn` PVC at `/app/data` — backed-up class on purpose: monitor definitions live in Kuma's SQLite DB
- Internal route `uptime.${SECRET_DOMAIN}`, homepage tile added
- First visit prompts admin-account setup (Kuma has no OIDC — local auth only); monitors to recreate from the old Gatus set: echo, Mattermost `/api/v4/system/ping`, Synapse `/health`, MAS, Element, Cloudflare `1.1.1.1`, Google
- Monitor auto-registration deferred by request — API wiring later

https://claude.ai/code/session_01ErKFq44HGff3qer14TseE2