### PR TITLE
feat(authentik): serve admin/user console on internal gateway only

### DIFF
--- a/kubernetes/apps/security/authentik/app/httproute-external.yaml
+++ b/kubernetes/apps/security/authentik/app/httproute-external.yaml
@@ -1,6 +1,17 @@
 ---
-# Expose Authentik externally for user login
-# This route is public (no forward-auth) as it IS the auth provider
+# Expose Authentik externally for user login & SSO ONLY.
+# This route is public (no forward-auth) as it IS the auth provider.
+#
+# The admin (`/if/admin`) and user (`/if/user`) consoles are deliberately NOT
+# served on the internet-facing gateway — they return a fixed 404 here (see
+# httproutefilter-deny-console.yaml) and remain reachable only via the internal
+# gateway (envoy-internal / split-DNS / Tailscale), where the chart-generated
+# `authentik-server` HTTPRoute serves the full app.
+#
+# Login flows, OAuth2/OIDC endpoints, the forward-auth outpost, the flow
+# interface (`/if/flow`), static assets and the API stay public via the
+# catch-all rule so external SSO keeps working. Path matches are most-specific-
+# wins, so the two console rules take precedence over the catch-all.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -14,6 +25,30 @@ spec:
       namespace: network
       sectionName: https
   rules:
+    # Admin console — 404 at the public edge (internal-only surface)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /if/admin
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: authentik-deny-console
+    # User console — 404 at the public edge (internal-only surface)
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /if/user
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: authentik-deny-console
+    # Everything else (login flows, OAuth2/OIDC, outpost, flow UI, API, static)
+    # stays public so external SSO keeps working.
     - backendRefs:
         - name: authentik-server
           port: 80

--- a/kubernetes/apps/security/authentik/app/httproutefilter-deny-console.yaml
+++ b/kubernetes/apps/security/authentik/app/httproutefilter-deny-console.yaml
@@ -1,0 +1,19 @@
+---
+# Fixed 404 returned for the Authentik admin/user console paths on the
+# INTERNET-facing route. Envoy Gateway extension filter, referenced from
+# httproute-external.yaml via an ExtensionRef filter.
+#
+# The consoles stay fully reachable via the internal gateway (envoy-internal /
+# split-DNS / Tailscale), where the chart-generated `authentik-server` HTTPRoute
+# serves the whole app. This only removes the admin/user UI from the public edge.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: authentik-deny-console
+  namespace: security
+spec:
+  directResponse:
+    statusCode: 404
+    body:
+      type: Inline
+      inline: "Not Found"

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - httproute-external.yaml
+  - httproutefilter-deny-console.yaml
   - referencegrant.yaml
 
 # Authentik config-as-code: passwordless passkey login + enrollment.


### PR DESCRIPTION
Restrict the Authentik admin/user console to the internal gateway; the public route returns 404 for those paths. Login and SSO are unchanged.

PR opened as a review gate before this auth-exposure change auto-deploys — rationale and validation live in working notes, not duplicated here.
