### PR TITLE
feat(coredns): split-DNS for internal hostnames inside the cluster

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -21,6 +21,16 @@ spec:
     replicaCount: 2
     servers:
       - zones:
+          - zone: ${SECRET_DOMAIN}.
+            scheme: dns://
+            use_tcp: true
+        port: 53
+        plugins:
+          - name: errors
+          - name: cache
+          - name: forward
+            parameters: . 10.43.222.7
+      - zones:
           - zone: .
             scheme: dns://
             use_tcp: true


### PR DESCRIPTION
In-cluster pods resolve the app domain via upstream public DNS, so internal-only hostnames NXDOMAIN (all new Uptime Kuma monitors down). Adds a CoreDNS server block forwarding the domain zone to the k8s-gateway ClusterIP.

Merging brings the 40 down monitors green.

https://claude.ai/code/session_01KDFeuRN4RVYDFWiHgyjN72