### PR TITLE
fix(coredns): autopath bypasses the split-DNS server block

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -21,16 +21,6 @@ spec:
     replicaCount: 2
     servers:
       - zones:
-          - zone: ${SECRET_DOMAIN}.
-            scheme: dns://
-            use_tcp: true
-        port: 53
-        plugins:
-          - name: errors
-          - name: cache
-          - name: forward
-            parameters: . 10.43.222.7
-      - zones:
           - zone: .
             scheme: dns://
             use_tcp: true
@@ -55,6 +45,8 @@ spec:
             parameters: IN AAAA
             configBlock: |-
               rcode NOERROR
+          - name: forward
+            parameters: ${SECRET_DOMAIN} 10.43.222.7
           - name: forward
             parameters: . /etc/resolv.conf
           - name: cache


### PR DESCRIPTION
Follow-up to #403. autopath short-circuits pods' search-suffixed queries inside the '.' server block, so hostnames with public DNS records (Seerr) resolved to the Cloudflare edge instead of envoy-internal — glibc getaddrinfo got public IPs while direct absolute queries got internal ones. Moves the domain-scoped forward into the '.' block (multiple zone-scoped forwards are supported) and drops the separate server block.

Merging brings the Seerr monitor green.

https://claude.ai/code/session_01KDFeuRN4RVYDFWiHgyjN72