### PR TITLE
fix(hermes-agent): wire dashboard SSO via Authentik to unblock stalled upgrade

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -28,6 +28,14 @@ spec:
         # cron/proactive delivery. SESSION_SCOPE=room isolates context per
         # room; AUTO_THREAD replaces Mattermost's REPLY_MODE=thread. E2EE off:
         # internal-only traffic, plain HTTP inside the cluster.
+        #
+        # Dashboard SSO (2026-07-19): v2026.7.x hardened the dashboard
+        # container to refuse a non-loopback bind with no auth provider
+        # registered. Wired to the bundled `self_hosted` OIDC plugin against
+        # Authentik (config-as-code in
+        # kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml).
+        # client_id is not secret (pinned, matches the blueprint); the client
+        # secret Authentik generated on first apply lives here.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
@@ -38,6 +46,9 @@ spec:
           MATRIX_SESSION_SCOPE=room
           MATRIX_AUTO_THREAD=true
           MATRIX_E2EE_MODE=off
+          HERMES_DASHBOARD_OIDC_ISSUER=https://auth.${SECRET_DOMAIN}/application/o/hermes/
+          HERMES_DASHBOARD_OIDC_CLIENT_ID=WFORCQ62bMifsYYZRZ7ranXU8l8eI47lTn3QQe1k
+          HERMES_DASHBOARD_OIDC_CLIENT_SECRET={{ .OIDC_CLIENT_SECRET }}
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:
@@ -47,3 +58,7 @@ spec:
       remoteRef:
         key: hermes-dotenv
         property: MATRIX_ACCESS_TOKEN
+    - secretKey: OIDC_CLIENT_SECRET
+      remoteRef:
+        key: hermes-dotenv
+        property: oidc_client_secret

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -50,6 +50,14 @@ spec:
               HERMES_HOME: /opt/data
               # Keep the hermes CLI on PATH here too (see gateway container note).
               PATH: /opt/hermes/.venv/bin:/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              # v2026.7.x refuses to bind the dashboard to 0.0.0.0 unless an
+              # auth provider is registered (--insecure no longer bypasses
+              # this). Wired to Authentik via the bundled self_hosted OIDC
+              # plugin — HERMES_DASHBOARD_OIDC_* vars ship in the mounted
+              # /opt/data/.env (see externalsecret-dotenv.yaml and
+              # kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml),
+              # loaded into the process env by hermes's own dotenv handling —
+              # same mechanism as MATRIX_* above.
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml
@@ -1,0 +1,65 @@
+# Hermes dashboard OIDC SSO — config-as-code.
+#
+# Authentik side of Hermes dashboard SSO. The v2026.7.x hermes-agent image
+# added a hard startup gate: the dashboard container refuses to bind to
+# 0.0.0.0 unless at least one dashboard auth provider is registered (the
+# bundled `--insecure` flag no longer satisfies this). Rather than app-local
+# basic auth, this wires the bundled `self_hosted` OIDC plugin
+# (hermes plugins/dashboard_auth/self_hosted) against Authentik — a generic,
+# standards-compliant OIDC Relying Party the image ships specifically for
+# self-hosted IDPs (Authentik/Keycloak/Zitadel/Authelia/...).
+#
+# client_id is PINNED so it stays consistent with the hermes-agent
+# HERMES_DASHBOARD_OIDC_CLIENT_ID env (kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml)
+# and the 1Password `hermes-dotenv` item across rebuilds.
+#
+# client_secret is intentionally OMITTED: on the live instance authentik
+# leaves it unchanged, so applying this never disturbs the working provider.
+# On a from-scratch rebuild authentik regenerates it — read the new secret
+# from Authentik > Providers > hermes and update the 1Password `hermes-dotenv`
+# item (field oidc_client_secret); the hermes-dotenv ExternalSecret then
+# repopulates HERMES_DASHBOARD_OIDC_CLIENT_SECRET.
+#
+# sub_mode is user_email — the self_hosted provider maps standard OIDC claims
+# (sub/email/name) onto its Session; email is the stable identity claim we
+# want since Hermes has no separate username concept for dashboard login.
+version: 1
+metadata:
+  name: hermes-oidc
+entries:
+  - model: authentik_providers_oauth2.oauth2provider
+    id: provider-hermes
+    identifiers:
+      name: hermes
+    attrs:
+      client_type: confidential
+      client_id: WFORCQ62bMifsYYZRZ7ranXU8l8eI47lTn3QQe1k
+      sub_mode: user_email
+      include_claims_in_id_token: true
+      issuer_mode: per_provider
+      grant_types:
+        - authorization_code
+        - refresh_token
+      redirect_uris:
+        - matching_mode: strict
+          url: https://hermes.${SECRET_DOMAIN}/auth/callback
+      authorization_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+      invalidation_flow:
+        !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+      signing_key:
+        !Find [authentik_crypto.certificatekeypair, [name, "authentik Self-signed Certificate"]]
+      property_mappings:
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-openid"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-profile"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-email"]]
+        - !Find [authentik_providers_oauth2.scopemapping, [managed, "goauthentik.io/providers/oauth2/scope-offline_access"]]
+
+  - model: authentik_core.application
+    id: app-hermes
+    identifiers:
+      slug: hermes
+    attrs:
+      name: Hermes
+      provider: !KeyOf provider-hermes
+      policy_engine_mode: any

--- a/kubernetes/apps/security/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/security/authentik/app/kustomization.yaml
@@ -20,6 +20,7 @@ configMapGenerator:
       - blueprints/setup-passkey.yaml
       - blueprints/headlamp-oidc.yaml
       - blueprints/matrix-oidc.yaml
+      - blueprints/hermes-oidc.yaml
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## Summary
- v2026.7.x hardened the hermes-agent dashboard container: it now refuses to bind 0.0.0.0 with no auth provider registered (`--insecure` no longer bypasses this)
- Every upgrade since the image tag bump has failed 3x and auto-rolled-back; HelmRelease has been `Stalled: RetriesExceeded` for ~19h, silently stuck on the pre-fix config (PR #394's PATH fix never actually landed)
- Wires the bundled `self_hosted` OIDC dashboard-auth plugin against Authentik, same config-as-code pattern as headlamp/matrix
- Provider + application already applied live to Authentik (via `ak shell` / Importer, same as the documented convention on the other blueprints) to unblock the deploy now; the blueprint file makes it durable across an Authentik rebuild
- Client secret stored in the `hermes-dotenv` 1Password item (`oidc_client_secret` field)

## Test plan
- [ ] Merge → Flux applies within seconds (webhook) → watch `flux get hr hermes-agent -n ai` and `kubectl get pods -n ai -l app.kubernetes.io/name=hermes-agent` for a clean 2/2 rollout
- [ ] Confirm the PATH fix landed: `hermes-cli doctor` should stop flagging `~/.local/bin/hermes not found`
- [ ] Browse to hermes.thegeekybits.com, confirm Authentik SSO login flow completes and dashboard loads