### PR TITLE
fix(hermes-agent): pin dashboard OAuth callback URL to fix Authentik redirect_uri mismatch

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -36,6 +36,15 @@ spec:
         # kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml).
         # client_id is not secret (pinned, matches the blueprint); the client
         # secret Authentik generated on first apply lives here.
+        #
+        # HERMES_DASHBOARD_PUBLIC_URL pins the OAuth callback URL (Tier-1
+        # operator-declared authority) instead of letting the dashboard
+        # reconstruct it from proxy headers. envoy-internal does not pass
+        # X-Forwarded-Proto through in a way uvicorn trusts, so the
+        # reconstructed callback came out as http:// and tripped Authentik's
+        # strict redirect_uri match. With this set, the callback is
+        # deterministically https://hermes.<domain>/auth/callback, matching
+        # the redirect_uri pinned in the Authentik hermes-oidc blueprint.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
@@ -49,6 +58,7 @@ spec:
           HERMES_DASHBOARD_OIDC_ISSUER=https://auth.${SECRET_DOMAIN}/application/o/hermes/
           HERMES_DASHBOARD_OIDC_CLIENT_ID=WFORCQ62bMifsYYZRZ7ranXU8l8eI47lTn3QQe1k
           HERMES_DASHBOARD_OIDC_CLIENT_SECRET={{ .OIDC_CLIENT_SECRET }}
+          HERMES_DASHBOARD_PUBLIC_URL=https://hermes.${SECRET_DOMAIN}
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:


### PR DESCRIPTION
## Summary
Follow-up to #405. The SSO gate is live but login hit Authentik's **Redirect URI Error** — the dashboard reconstructs its OIDC callback from proxy headers, and behind `envoy-internal` `X-Forwarded-Proto: https` isn't trusted by uvicorn, so the callback resolved to `http://hermes.thegeekybits.com/auth/callback`. Authentik's strict `redirect_uri` match rejects the scheme mismatch.

Sets `HERMES_DASHBOARD_PUBLIC_URL=https://hermes.${SECRET_DOMAIN}` — the plugin's documented Tier-1 "operator-declared authority" path that bypasses proxy-header guessing. Callback is now deterministically `https://hermes.thegeekybits.com/auth/callback`, matching the redirect_uri pinned in the `hermes-oidc` blueprint.

## Verification (done live in-pod before commit)
- Without the var: `redirect_uri = http://hermes.thegeekybits.com/auth/callback` (the bug)
- With the var: `redirect_uri = https://hermes.thegeekybits.com/auth/callback` (matches blueprint)

## Test plan
- [ ] Merge → Flux applies → ExternalSecret re-renders `.env` → reloader bounces the pod
- [ ] Browse hermes.thegeekybits.com → Authentik login completes → dashboard loads