### PR TITLE
fix(hermes-agent): restore Mattermost alongside Matrix, fix dashboard probe

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -36,6 +36,15 @@ spec:
         # kubernetes/apps/security/authentik/app/blueprints/hermes-oidc.yaml).
         # client_id is not secret (pinned, matches the blueprint); the client
         # secret Authentik generated on first apply lives here.
+        #
+        # HERMES_DASHBOARD_PUBLIC_URL pins the OAuth callback URL (Tier-1
+        # operator-declared authority) instead of letting the dashboard
+        # reconstruct it from proxy headers. envoy-internal does not pass
+        # X-Forwarded-Proto through in a way uvicorn trusts, so the
+        # reconstructed callback came out as http:// and tripped Authentik's
+        # strict redirect_uri match. With this set, the callback is
+        # deterministically https://hermes.<domain>/auth/callback, matching
+        # the redirect_uri pinned in the Authentik hermes-oidc blueprint.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
           MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
@@ -49,6 +58,7 @@ spec:
           HERMES_DASHBOARD_OIDC_ISSUER=https://auth.${SECRET_DOMAIN}/application/o/hermes/
           HERMES_DASHBOARD_OIDC_CLIENT_ID=WFORCQ62bMifsYYZRZ7ranXU8l8eI47lTn3QQe1k
           HERMES_DASHBOARD_OIDC_CLIENT_SECRET={{ .OIDC_CLIENT_SECRET }}
+          HERMES_DASHBOARD_PUBLIC_URL=https://hermes.${SECRET_DOMAIN}
   data:
     - secretKey: API_SERVER_KEY
       remoteRef:

--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -19,15 +19,28 @@ spec:
         # still deferred — add fields to the hermes-dotenv 1Password item and
         # reference them here when enabling.
         #
-        # Matrix cutover (2026-07-17, replaces the Mattermost adapter): the
-        # gateway auto-enables the bundled Matrix platform adapter from
-        # MATRIX_HOMESERVER/MATRIX_ACCESS_TOKEN presence. Bot @hermes lives on
-        # the internal Synapse (auth delegated to MAS; token is a MAS
-        # compatibility token). Access is allowlisted to Shawn instead of the
-        # old allow-all; MATRIX_HOME_ROOM is the private #hermes-home room for
-        # cron/proactive delivery. SESSION_SCOPE=room isolates context per
-        # room; AUTO_THREAD replaces Mattermost's REPLY_MODE=thread. E2EE off:
-        # internal-only traffic, plain HTTP inside the cluster.
+        # Matrix cutover (2026-07-17) was originally meant to replace the
+        # Mattermost adapter, but Shawn decided (2026-07-19) to run both side
+        # by side while he evaluates dropping Matrix later — so both
+        # platform blocks are wired here. The gateway auto-enables each
+        # bundled adapter purely from its own env vars being present
+        # (MATTERMOST_URL/MATTERMOST_TOKEN and MATRIX_HOMESERVER/
+        # MATRIX_ACCESS_TOKEN respectively); no HelmRelease/config.yaml
+        # change needed to run both at once.
+        #
+        # Mattermost: bot account "hermes" in the mixos team, open to any
+        # user in this internal-only instance; MATTERMOST_HOME_CHANNEL is
+        # the dedicated #hermes-home channel for cron/proactive delivery;
+        # MATTERMOST_REPLY_MODE=thread keeps @mention/channel replies in the
+        # originating thread instead of posting new root messages.
+        #
+        # Matrix: bot @hermes lives on the internal Synapse (auth delegated
+        # to MAS; token is a MAS compatibility token). Access is allowlisted
+        # to Shawn instead of Mattermost's allow-all; MATRIX_HOME_ROOM is the
+        # private #hermes-home room for cron/proactive delivery.
+        # SESSION_SCOPE=room isolates context per room; AUTO_THREAD mirrors
+        # Mattermost's REPLY_MODE=thread. E2EE off: internal-only traffic,
+        # plain HTTP inside the cluster.
         #
         # Dashboard SSO (2026-07-19): v2026.7.x hardened the dashboard
         # container to refuse a non-loopback bind with no auth provider
@@ -47,6 +60,11 @@ spec:
         # the redirect_uri pinned in the Authentik hermes-oidc blueprint.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
+          MATTERMOST_URL=http://mattermost-main.tools.svc.cluster.local:8065
+          MATTERMOST_TOKEN={{ .MATTERMOST_TOKEN }}
+          MATTERMOST_ALLOW_ALL_USERS=true
+          MATTERMOST_HOME_CHANNEL=4qkyyzxfejdtuqpdkkiatbemur
+          MATTERMOST_REPLY_MODE=thread
           MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
           MATRIX_ACCESS_TOKEN={{ .MATRIX_ACCESS_TOKEN }}
           MATRIX_USER_ID=@hermes:matrix.${SECRET_DOMAIN}
@@ -64,6 +82,10 @@ spec:
       remoteRef:
         key: hermes-dotenv
         property: password
+    - secretKey: MATTERMOST_TOKEN
+      remoteRef:
+        key: hermes-dotenv
+        property: MATTERMOST_TOKEN
     - secretKey: MATRIX_ACCESS_TOKEN
       remoteRef:
         key: hermes-dotenv

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -59,12 +59,19 @@ spec:
               # loaded into the process env by hermes's own dotenv handling —
               # same mechanism as MATRIX_* above.
             probes:
+              # OIDC hardening (2026-07-19) made "/" redirect unauthenticated
+              # requests to the Authentik login page (302), which kubelet's
+              # httpGet probe treats as a failure ("Probe terminated
+              # redirects") — the dashboard container was restarting on a
+              # flapping liveness check. /favicon.ico is a static asset that
+              # returns 200 without auth, so it's a safe unauthenticated
+              # health check target instead.
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /
+                    path: /favicon.ico
                     port: 9119
                   initialDelaySeconds: 30
                   periodSeconds: 30


### PR DESCRIPTION
## Summary
- Re-adds MATTERMOST_URL/TOKEN/HOME_CHANNEL/REPLY_MODE to hermes-dotenv — the 2026-07-17 Matrix cutover replaced Mattermost instead of running alongside it as intended; Shawn wants both live for now
- Fixes dashboard liveness/readiness probe: OIDC hardening made `/` redirect (302) to Authentik login, which kubelet's httpGet probe treats as failure, causing restart-flapping — repointed to `/favicon.ico` (confirmed unauthenticated 200)

## Test plan
- [ ] Merge to main, confirm Flux webhook deploy (Reloader-driven rollout on hermes-dotenv secret change)
- [ ] `kubectl logs -n ai deploy/hermes-agent -c gateway` shows both Mattermost and Matrix platform adapters connecting
- [ ] Send a message in the Mattermost #hermes-home channel / mention the bot, confirm reply
- [ ] `kubectl get events -n ai` — no further dashboard ProbeWarning/restarts after rollout settles