### PR TITLE
fix(hermes-agent): raise dashboard memory to stop OOMKills

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -81,9 +81,9 @@ spec:
             resources:
               requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 256Mi
               limits:
-                memory: 512Mi
+                memory: 1Gi
 
     service:
       main:


### PR DESCRIPTION
## Problem
`hermes-agent` `dashboard` container is **OOMKilled** (exit 137) at its 512Mi limit → CrashLoopBackOff → client disconnects during use.

Observed on `hermes-agent-5c4d7c47bc-tt4zw`: dashboard restartCount=4, lastState `OOMKilled`, BackOff events. Gateway container healthy (321Mi/3Gi, 0 restarts).

## Change
- dashboard memory **limit 512Mi → 1Gi**
- dashboard memory **request 128Mi → 256Mi**
- gateway unchanged

## Verify after Flux reconcile
`kubectl -n ai get pod -l app.kubernetes.io/name=hermes-agent` → dashboard Running, no new OOMKills; `kubectl -n ai top pod --containers` steady under 1Gi.

https://claude.ai/code/session_011Ws7ZWmKWwk923LGEZ35jh