### PR TITLE
feat(notifications): move infra alerts from Discord to Mattermost #infrastructure

### DIFF
--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/cronjob.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/cronjob.yaml
@@ -37,13 +37,17 @@ spec:
               env:
                 - name: METRICS_URL
                   value: "http://longhorn-backend.longhorn-system:9500/metrics"
-                - name: APPRISE_URL
-                  value: "http://apprise.tools:8000/notify"
-                - name: DISCORD_WEBHOOK_URL
+                # Mattermost delivery: post to #infrastructure via the Jarvis
+                # bot token (native avatar + name), internal cluster URL.
+                - name: MATTERMOST_URL
+                  value: "http://mattermost-main.tools.svc.cluster.local:8065"
+                - name: MATTERMOST_CHANNEL_ID
+                  value: "6qik9sorwbfcmdzqpwuwhwk69r"
+                - name: MATTERMOST_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: longhorn-backup-alert-secret
-                      key: DISCORD_WEBHOOK_URL
+                      key: MATTERMOST_TOKEN
               command: ["/bin/sh", "-c"]
               args:
                 - |
@@ -58,19 +62,16 @@ spec:
                   fi
                   COUNT=$(printf '%s\n' "${FAILED}" | grep -c .)
                   VOLS=$(printf '%s\n' "${FAILED}" | sed -n 's/.*volume="\([^"]*\)".*/\1/p' | sort -u | tr '\n' ' ')
-                  MSG="Longhorn backup failure: ${COUNT} backup(s) in Error state. Volume(s): ${VOLS}"
+                  # Volume names are k8s-safe (lowercase alphanumerics + dashes),
+                  # so no JSON escaping beyond the static text is required.
+                  MSG="**Longhorn backup failure**: ${COUNT} backup(s) in Error state. Volume(s): ${VOLS}"
                   echo "[$(date -u)] ${MSG}"
-                  # Convert https://discord.com/api/webhooks/ID/TOKEN -> apprise discord://ID/TOKEN
-                  IDTOK=$(printf '%s' "${DISCORD_WEBHOOK_URL}" | sed -n 's#.*/webhooks/\([0-9][0-9]*\)/\([A-Za-z0-9_-][A-Za-z0-9_-]*\).*#\1/\2#p')
-                  if [ -z "${IDTOK}" ]; then
-                    echo "ERROR: could not parse Discord webhook URL into apprise format" >&2
-                    exit 1
-                  fi
-                  curl -sf --max-time 20 -X POST "${APPRISE_URL}" \
-                    --data-urlencode "urls=discord://${IDTOK}" \
-                    --data-urlencode "title=Longhorn backup failure" \
-                    --data-urlencode "body=${MSG}" >/dev/null
-                  echo "[$(date -u)] Alert dispatched via apprise."
+                  # Post to Mattermost #infrastructure via the Jarvis bot REST API.
+                  curl -sf --max-time 20 -X POST "${MATTERMOST_URL}/api/v4/posts" \
+                    -H "Authorization: Bearer ${MATTERMOST_TOKEN}" \
+                    -H "Content-Type: application/json" \
+                    -d "{\"channel_id\":\"${MATTERMOST_CHANNEL_ID}\",\"message\":\"${MSG}\"}" >/dev/null
+                  echo "[$(date -u)] Alert dispatched to Mattermost #infrastructure."
               resources:
                 requests:
                   cpu: 10m

--- a/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/externalsecret.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn-backup-alert/app/externalsecret.yaml
@@ -12,7 +12,9 @@ spec:
     name: longhorn-backup-alert-secret
     template:
       data:
-        DISCORD_WEBHOOK_URL: "{{ .password }}"
+        # Jarvis bot token — posts to Mattermost #infrastructure via REST
+        # (native bot avatar + name). See 1P item `mattermost-jarvis-bot`.
+        MATTERMOST_TOKEN: "{{ .token }}"
   dataFrom:
     - extract:
-        key: discord-webhook-jarvis
+        key: mattermost-jarvis-bot

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/externalsecret.yaml
@@ -11,6 +11,11 @@ spec:
   target:
     name: alertmanager-config
     template:
+      # Mattermost incoming webhooks are Slack-compatible, so Alertmanager's
+      # native slack_configs deliver straight to #infrastructure — no Discord,
+      # no bridge. `internal_url` is the in-cluster /hooks/<token> URL (http,
+      # no external DNS/TLS dependency). Title/text are left to Alertmanager's
+      # slack defaults so no Go-template braces leak into the ESO template.
       data:
         alertmanager.yaml: |
           route:
@@ -18,16 +23,17 @@ spec:
             group_wait: 1m
             group_interval: 10m
             repeat_interval: 12h
-            receiver: discord
+            receiver: mattermost
             routes:
               - receiver: "null"
                 matchers:
                   - alertname =~ "Watchdog|InfoInhibitor"
           receivers:
             - name: "null"
-            - name: discord
-              discord_configs:
-                - webhook_url: "{{ .password }}"
+            - name: mattermost
+              slack_configs:
+                - api_url: "{{ .internal_url }}"
+                  username: "Jarvis"
                   send_resolved: true
           inhibit_rules:
             - source_matchers: ["severity = critical"]
@@ -38,4 +44,4 @@ spec:
               equal: ["alertname", "namespace"]
   dataFrom:
     - extract:
-        key: discord-webhook-jarvis
+        key: mattermost-webhook-infra

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -74,8 +74,9 @@ spec:
     alertmanager:
       enabled: true
       alertmanagerSpec:
-        # Full config rendered by the alertmanager ExternalSecret (webhook
-        # inline — the operator's parser rejects discord webhook_url_file)
+        # Full config rendered by the alertmanager ExternalSecret. Delivery is
+        # Mattermost #infrastructure via a Slack-compatible incoming webhook
+        # (api_url inline; the operator's parser rejects *_file indirection).
         configSecret: alertmanager-config
         storage:
           volumeClaimTemplate:

--- a/kubernetes/apps/network/cloudflare-dns-monitor/app/cronjob.yaml
+++ b/kubernetes/apps/network/cloudflare-dns-monitor/app/cronjob.yaml
@@ -37,26 +37,32 @@ spec:
                   value: "1"
                 - name: ZONE_NAME
                   value: "${SECRET_DOMAIN}"
-                - name: APPRISE_URL
-                  value: "http://apprise.tools:8000/notify"
+                # Mattermost delivery: post to #infrastructure via the Jarvis
+                # bot token (native avatar + name). Internal cluster URL — no
+                # external DNS/TLS dependency.
+                - name: MATTERMOST_URL
+                  value: "http://mattermost-main.tools.svc.cluster.local:8065"
+                - name: MATTERMOST_CHANNEL_ID
+                  value: "6qik9sorwbfcmdzqpwuwhwk69r"
+                - name: MATTERMOST_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: cloudflare-dns-monitor-secret
+                      key: MATTERMOST_TOKEN
                 - name: CF_API_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: cloudflare-dns-secret
                       key: api-token
-                - name: DISCORD_WEBHOOK_URL
-                  valueFrom:
-                    secretKeyRef:
-                      name: cloudflare-dns-monitor-secret
-                      key: DISCORD_WEBHOOK_URL
               command: ["python3", "-c"]
               args:
                 - |
-                  import json, os, re, sys, urllib.request, urllib.parse
+                  import json, os, sys, urllib.request, urllib.parse
                   CF = os.environ["CF_API_TOKEN"]
                   ZONE = os.environ["ZONE_NAME"]
-                  APPRISE = os.environ["APPRISE_URL"]
-                  WEBHOOK = os.environ["DISCORD_WEBHOOK_URL"]
+                  MM = os.environ["MATTERMOST_URL"].rstrip("/")
+                  MM_TOKEN = os.environ["MATTERMOST_TOKEN"]
+                  MM_CHANNEL = os.environ["MATTERMOST_CHANNEL_ID"]
                   STATE = "/state/seen-records.json"
                   API = "https://api.cloudflare.com/client/v4"
 
@@ -64,6 +70,15 @@ spec:
                       req = urllib.request.Request(API + path, headers={"Authorization": "Bearer " + CF})
                       with urllib.request.urlopen(req, timeout=20) as r:
                           return json.load(r)
+
+                  def mm_post(message):
+                      data = json.dumps({"channel_id": MM_CHANNEL, "message": message}).encode()
+                      req = urllib.request.Request(
+                          MM + "/api/v4/posts", data=data,
+                          headers={"Authorization": "Bearer " + MM_TOKEN,
+                                   "Content-Type": "application/json"})
+                      with urllib.request.urlopen(req, timeout=20) as r:
+                          r.read()
 
                   zr = cf("/zones?name=" + urllib.parse.quote(ZONE)).get("result") or []
                   if not zr:
@@ -97,19 +112,10 @@ spec:
                       if sections:
                           body = "Cloudflare DNS change(s) in %s:\n\n%s" % (ZONE, "\n\n".join(sections))
                           print(body)
-                          m = re.search(r"/webhooks/(\d+)/([\w-]+)", WEBHOOK)
-                          if not m:
-                              print("ERROR: cannot parse Discord webhook URL", file=sys.stderr)
-                              sys.exit(1)
-                          data = urllib.parse.urlencode({
-                              "urls": "discord://%s/%s" % (m.group(1), m.group(2)),
-                              "title": "DNS change in %s (+%d ~%d -%d)" % (
-                                  ZONE, len(added), len(changed), len(removed)),
-                              "body": body,
-                          }).encode()
-                          with urllib.request.urlopen(urllib.request.Request(APPRISE, data=data), timeout=20) as r:
-                              r.read()
-                          print("Alert dispatched via apprise.")
+                          message = "**DNS change in %s** (+%d ~%d -%d)\n\n%s" % (
+                              ZONE, len(added), len(changed), len(removed), body)
+                          mm_post(message)
+                          print("Alert dispatched to Mattermost #infrastructure.")
                       else:
                           print("No DNS changes (%d total)." % len(current))
 

--- a/kubernetes/apps/network/cloudflare-dns-monitor/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-dns-monitor/app/externalsecret.yaml
@@ -12,7 +12,9 @@ spec:
     name: cloudflare-dns-monitor-secret
     template:
       data:
-        DISCORD_WEBHOOK_URL: "{{ .password }}"
+        # Jarvis bot token — posts to Mattermost #infrastructure via REST
+        # (native bot avatar + name). See 1P item `mattermost-jarvis-bot`.
+        MATTERMOST_TOKEN: "{{ .token }}"
   dataFrom:
     - extract:
-        key: discord-webhook-jarvis
+        key: mattermost-jarvis-bot


### PR DESCRIPTION
Routes homelab notifications to the internal **Mattermost #infrastructure** channel as the **Jarvis** bot, replacing Discord.

## What changed
| App | Before | After |
|---|---|---|
| `cloudflare-dns-monitor` | Discord via apprise | Jarvis bot REST (`/api/v4/posts`, internal svc URL) |
| `longhorn-backup-alert` | Discord via apprise | Jarvis bot REST |
| `kube-prometheus-stack` alertmanager | `discord_configs` | Slack-compatible incoming webhook (Mattermost speaks Slack's webhook format) |

## The repeatable pattern
One reusable primitive per delivery style, both in the `homeops` 1Password vault:
- **`mattermost-jarvis-bot`** → `.token` — bot access token. Any script/cronjob POSTs to `{MATTERMOST_URL}/api/v4/posts` with `channel_id` + `message` (+ optional `file_ids`). Native bot avatar + name. This is the default for anything that can speak REST.
- **`mattermost-webhook-infra`** → `.internal_url` / `.password` — a Slack-compatible incoming webhook for tools that only emit webhooks (Alertmanager). Bound to #infrastructure.

New consumers: drop in a per-app ExternalSecret extracting one of those items, then post. No new infra.

## Validation (pre-merge)
- Mattermost bot-token REST post, HTML **file-attachment** post, and Slack-compat webhook post all return 2xx against the live instance.
- ESO resolution of both 1P items verified with a throwaway probe ExternalSecret (`SecretSynced`, non-empty values). Note: the token lives in a **custom** `token` field because ESO's 1Password provider does not expose the API-Credential built-in `credential` field.
- In-cluster reachability to `mattermost-main.tools.svc.cluster.local:8065` confirmed (HTTP 200).

## Notes
- Attribution: posts render as **Jarvis** (bot avatar set to the provided portrait). Required enabling `EnablePostUsernameOverride`/`EnablePostIconOverride` for the webhook path.
- Not touched: `tools/bridge` still uses Discord (ledger app, out of scope).
- Companion change (already merged, separate repo): the local weekly Claude `/insights` job now delivers to this same channel as an HTML file attachment.

https://claude.ai/code/session_016LDQAAEcDPCnPutjPj9ZrE