### PR TITLE
fix(home-assistant): resolve ha_hatch awscrt version split

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -14,6 +14,36 @@ spec:
         type: statefulset
         annotations:
           reloader.stakater.com/auto: "true"
+        # TEMPORARY WORKAROUND (2026-07-26) — remove once awscrt ships a fix.
+        #
+        # The HA image ships awscrt 0.32.1 (pre-installed for the core lg_thinq
+        # integration). At runtime the ha_hatch custom component installs
+        # hatch_rest_api==1.34.1, whose unpinned awsiotsdk>=1.16.0 resolves to
+        # 1.31.0 and pins awscrt==0.36.1 — upgrading awscrt on disk mid-boot.
+        # awscrt.io is already imported at 0.32.1, whose ClientTlsContext.__slots__
+        # has no '_certificate_source', while awscrt.aws_iot_metrics (a module that
+        # only exists in 0.36.x) then imports fresh from 0.36.1 and reads that
+        # attribute -> AttributeError every coordinator poll (~80s), which both
+        # floods the log and leaves all Hatch entities dead.
+        #
+        # Fix: seed a persistent, self-consistent awscrt 0.36.1 under /config/pydeps
+        # and put it first on sys.path via PYTHONPATH, so every awscrt submodule
+        # resolves from one install regardless of what HA does to site-packages.
+        initContainers:
+          awscrt-pin:
+            image:
+              repository: ghcr.io/home-assistant/home-assistant
+              tag: 2026.5.4
+            command:
+              - sh
+              - -c
+              - pip install --quiet --upgrade --target /config/pydeps "awsiotsdk==1.31.0"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
         containers:
           app:
             image:
@@ -21,6 +51,8 @@ spec:
               tag: 2026.5.4
             env:
               TZ: America/New_York
+              # See the awscrt-pin initContainer above.
+              PYTHONPATH: /config/pydeps
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Problem

`ha_hatch` throws this every ~80s, flooding the HA log and leaving all Hatch entities dead:

```
ERROR [custom_components.ha_hatch.hatch_data_update_coordinator]
'ClientTlsContext' object has no attribute '_certificate_source'
```

## Root cause

A **version split inside awscrt**, not a Hatch bug:

1. The HA image ships **awscrt 0.32.1**, pre-installed for the core `lg_thinq` integration (verified by booting a clean `ghcr.io/home-assistant/home-assistant:2026.5.4` container).
2. `awscrt.io` gets imported at 0.32.1, whose `ClientTlsContext.__slots__` has no `_certificate_source`.
3. ~26s into boot, HA installs `ha_hatch`'s `hatch_rest_api==1.34.1`. Its unpinned `awsiotsdk>=1.16.0` resolves to 1.31.0, which pins `awscrt==0.36.1` — **upgrading awscrt on disk mid-run**.
4. On first Hatch connect, `awscrt.aws_iot_metrics` — a module that exists *only* in 0.36.x — imports fresh from 0.36.1 and reads `tls_ctx._certificate_source` against the old in-memory class.

Timeline confirms it: HA process start `07-24 15:56:36`, awscrt written `07-26 20:24:07`, first error `07-26 20:25:06`.

Why it started on 2026-07-26 and not earlier: awscrt 0.35.x had **no** `aws_iot_metrics.py`, so the identical version split was harmless until 0.36.0 added it.

awscrt 0.36.1 is fine on its own — in a clean process in the same container, the metrics path returns `F/3,G/A` without error. The bug is purely the split.

## Approaches ruled out

- **Pinning `awsiotsdk` in `ha_hatch`'s `manifest.json`** — tried both orderings, neither held. HA installs requirements **concurrently**, so `hatch_rest_api`'s resolve wins the race regardless of order.
- **`/config/deps`** — HA disables that path under Docker (`requirements.py:104`).
- **Restarting HA** — no effect; the container FS resets to the image's 0.32.1 and the same upgrade re-runs every boot.

## Fix

Seed a persistent, self-consistent awscrt 0.36.1 under `/config/pydeps` via an initContainer, and put it first on `sys.path` with `PYTHONPATH`. Every awscrt submodule then resolves from one install regardless of what HA does to site-packages.

Verified in-cluster that with `PYTHONPATH=/config/pydeps`, both `awscrt.io` and `awscrt.aws_iot_metrics` load from `/config/pydeps` at 0.36.1 with the slot present.

## Notes

- **Temporary** — remove once awscrt/awsiotsdk fix this upstream. The real upstream fix is for `aws_iot_metrics` to use `getattr(tls_ctx, '_certificate_source', None)`. No upstream issue exists yet.
- Not verified end-to-end on the live cluster — needs a Flux reconcile and HA restart. Hatch's cloud API rate-limits repeated logins, so I stopped short of another restart cycle.
- `/config/pydeps` already exists on the PVC from validation; the initContainer makes it declarative and idempotent.

https://claude.ai/code/session_01WpMryCZgzGdWm9bP4DmMXd
