### PR TITLE
feat(forgejo): disable legacy OpenID 2.0, document Authentik OIDC source

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -52,9 +52,13 @@ spec:
         repository:
           DEFAULT_PRIVATE: last
 
+        # Legacy OpenID 2.0 (NOT OIDC). Left enabled, this renders a
+        # "Proceed with OpenID" button that prompts for an OpenID 2.0 URI —
+        # a dead protocol, and easily mistaken for the Authentik SSO button.
+        # SSO is OAuth2/OIDC via the auth source below, not this.
         openid:
-          ENABLE_OPENID_SIGNIN: true
-          ENABLE_OPENID_SIGNUP: true
+          ENABLE_OPENID_SIGNIN: false
+          ENABLE_OPENID_SIGNUP: false
 
         ui:
           DEFAULT_THEME: catppuccin-mocha-blue
@@ -78,10 +82,18 @@ spec:
             catppuccin-green-auto,catppuccin-teal-auto,catppuccin-sky-auto,catppuccin-sapphire-auto,
             catppuccin-blue-auto,catppuccin-lavender-auto
 
-        # OIDC is configured post-deploy via Forgejo admin UI:
-        # Administration > Identity & Access > Authentication Sources
-        # Provider: OpenID Connect
-        # Discovery URL: https://authentik.${SECRET_DOMAIN}/application/o/forgejo/.well-known/openid-configuration
+        # OIDC auth source "authentik" — created 2026-07-30, lives in Forgejo's
+        # own DB (not templatable via app.ini), so it is NOT declared here.
+        # Recreate after a data loss with:
+        #   forgejo admin auth add-oauth --name authentik \
+        #     --provider openidConnect --key <client_id> --secret <client_secret> \
+        #     --auto-discover-url \
+        #       https://auth.${SECRET_DOMAIN}/application/o/forgejo/.well-known/openid-configuration \
+        #     --scopes "openid email profile"
+        # Credentials: 1Password homeops/forgejo (oidc.client_id, oidc.client_secret).
+        # Authentik side: OAuth2 provider "forgejo" bound to application "Forgejo";
+        # redirect URI https://git.${SECRET_DOMAIN}/user/oauth2/authentik/callback
+        # (the path segment must match the auth source name above).
 
     # Forgejo runs on its embedded SQLite database (DB_TYPE=sqlite3), which is
     # appropriate for this single-user homelab instance. The forgejo-helm chart


### PR DESCRIPTION
Forgejo SSO was half-wired: the Authentik application existed with no provider bound, and Forgejo had zero auth sources. The only visible "OpenID" button was legacy OpenID 2.0, which prompts for an OpenID 2.0 URI.

Completed out-of-band (auth source lives in Forgejo's DB, not app.ini): Authentik OAuth2 provider created and bound to the Forgejo application, Forgejo auth source `authentik` added, credentials stored in 1Password.

This PR turns off legacy OpenID 2.0 and replaces the stale comment with the actual recreate steps.

https://claude.ai/code/session_01EzN3SxQj4xbk6Be4b38AKh