### PR TITLE
feat(database): add CloudNativePG operator

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cloudnative-pg
+  interval: 1h
+  values:
+    # CRDs ship in-chart. The root cluster-apps patch already forces
+    # install.crds/upgrade.crds: CreateReplace on every HelmRelease.
+    crds:
+      create: true
+
+    config:
+      # Operator watches every namespace, so Cluster resources can live wherever
+      # they make sense. The shared cluster lives here in `database`, but this
+      # leaves the door open for a per-app Cluster later without a second operator.
+      clusterWide: true
+
+    monitoring:
+      # Prometheus discovers PodMonitors in all namespaces
+      # (*SelectorNilUsesHelmValues: false in kube-prometheus-stack).
+      podMonitorEnabled: true
+      grafanaDashboard:
+        # Grafana's sidecar uses searchNamespace: ALL, so the ConfigMap is found
+        # here in `database` — no namespace override needed.
+        create: true
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.27.0
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  # wait: true — CRD provider. Every Cluster/Database resource and every app
+  # that later depends on Postgres is gated behind the operator being Ready.
+  wait: true
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: cloudnative-pg
+      namespace: database

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./cloudnative-pg/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
**PR 1 of 5** — Forgejo CI/CD + Postgres consolidation.

Deploys the CloudNativePG operator into a new `database` namespace. Nothing else changes; no `Cluster` exists yet, so this is inert until PR2.

### Why

Forgejo is on SQLite on an RWO Longhorn volume. Enabling Actions puts concurrent writers (job queue rows, step logs, artifact metadata) on it, which is the classic `database is locked` failure. Moving Forgejo to Postgres is the prerequisite for CI/CD.

Rather than bolt a Postgres sidecar onto Forgejo alone, this deploys an operator sized to eventually absorb all ten existing `postgres:18-alpine` sidecars (n8n, teslamate, atuin, mas, mattermost, nextcloud, shlink, synapse, zipline) plus Authentik. Forgejo is the first tenant; the rest follow via a documented runbook.

### Design notes

- **Operator and Clusters share the `database` namespace.** The chart creates `cnpg-default-monitoring` in the operator's namespace and a `Cluster` resolves that name in its own — co-locating makes the default metric queries work with zero copying.
- **`config.clusterWide: true`** so a per-app `Cluster` elsewhere never needs a second operator.
- **`wait: true` + HelmRelease health check.** CRD provider: everything downstream must gate on the operator being Ready, not merely applied.
- CRDs come from the chart; the root `cluster-apps` patch already forces `crds: CreateReplace` on every HelmRelease.

### Verification

```
kubectl get crd | grep cnpg.io          # expect 9
kubectl -n database get pods            # operator Running
kubectl -n database get cm cnpg-default-monitoring
```

### Rollback

Delete the `database` directory. No stateful resource exists at this point.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH