### PR TITLE
feat(database): add shared Postgres cluster and logical backups

### DIFF
--- a/kubernetes/apps/database/db-backup/app/cronjob-postgres.yaml
+++ b/kubernetes/apps/database/db-backup/app/cronjob-postgres.yaml
@@ -1,0 +1,105 @@
+---
+# Logical backup for the whole shared CNPG cluster: globals (roles, tablespaces)
+# plus a custom-format dump per database. Replaces the per-app pg_dump cronjobs
+# as each app migrates onto this cluster — see docs/postgres-consolidation.md.
+#
+# This is the AUTHORITATIVE backup. CNPG's native barman backups need an S3
+# endpoint, and no object storage exists in this cluster (Longhorn's only
+# off-box target is NFS to the Synology, which barman-cloud cannot use).
+#
+# NOTE: the parent Kustomization intentionally declares no postBuild
+# substituteFrom, so shell ${VAR} below needs no $${} escaping — same as every
+# other db-backup CronJob in this repo.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: db-backup-postgres
+spec:
+  # Fits the existing 01:00-02:30 stagger, well ahead of Longhorn's 03:00
+  # backup-daily job which then ships this PVC off-box.
+  schedule: "20 1 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: dump
+              # Matches the server major version (18). Consistent with the eight
+              # existing db-backup CronJobs; pg_dump is compatible across minors.
+              image: postgres:18-alpine
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: ["ALL"]
+              env:
+                - name: PGHOST
+                  value: postgres-rw.database.svc.cluster.local
+                - name: PGPORT
+                  value: "5432"
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-superuser-secret
+                      key: username
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-superuser-secret
+                      key: password
+                - name: RETENTION_DAYS
+                  value: "14"
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  TS=$(date +%Y%m%d-%H%M%S)
+
+                  echo "[$(date -u)] pg_dumpall --globals-only"
+                  pg_dumpall --globals-only --no-role-passwords \
+                    --dbname=postgres > "/backups/globals-${TS}.sql"
+                  ls -lh "/backups/globals-${TS}.sql"
+
+                  DBS=$(psql --dbname=postgres -Atc \
+                    "SELECT datname FROM pg_database WHERE NOT datistemplate AND datallowconn")
+
+                  for DB in ${DBS}; do
+                    OUT="/backups/${DB}-${TS}.dump"
+                    echo "[$(date -u)] pg_dump ${DB} -> ${OUT}"
+                    pg_dump --dbname="${DB}" --no-owner --no-privileges \
+                      --format=custom --compress=9 --file="${OUT}"
+                    ls -lh "${OUT}"
+                  done
+
+                  echo "Pruning dumps older than ${RETENTION_DAYS}d"
+                  find /backups -maxdepth 1 -type f \
+                    \( -name '*.dump' -o -name 'globals-*.sql' \) \
+                    -mtime +${RETENTION_DAYS} -print -delete
+                  echo "done"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  memory: 512Mi
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: db-backups

--- a/kubernetes/apps/database/db-backup/app/kustomization.yaml
+++ b/kubernetes/apps/database/db-backup/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./pvc.yaml
+  - ./cronjob-postgres.yaml

--- a/kubernetes/apps/database/db-backup/app/pvc.yaml
+++ b/kubernetes/apps/database/db-backup/app/pvc.yaml
@@ -1,0 +1,19 @@
+---
+# Holds logical dumps for every database on the shared CNPG cluster, so it is
+# sized larger than the per-namespace 5Gi db-backups PVCs it will eventually
+# replace. On `longhorn` (not longhorn-nobackup) so Longhorn's default
+# recurring-job group ships it off-box to the Synology at 03:00 — one hour
+# after the dump completes.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: db-backups
+  labels:
+    app.kubernetes.io/name: db-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/apps/database/db-backup/ks.yaml
+++ b/kubernetes/apps/database/db-backup/ks.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: db-backup
+spec:
+  dependsOn:
+    - name: postgres
+  interval: 1h
+  path: ./kubernetes/apps/database/db-backup/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: false

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -9,3 +9,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./cloudnative-pg/ks.yaml
+  - ./postgres/ks.yaml
+  - ./db-backup/ks.yaml

--- a/kubernetes/apps/database/postgres/app/cluster.yaml
+++ b/kubernetes/apps/database/postgres/app/cluster.yaml
@@ -1,0 +1,68 @@
+---
+# Shared PostgreSQL cluster. Replaces the per-app `postgres:18-alpine` sidecar
+# pattern documented in docs/deployment-plan.md. Apps migrate onto it one at a
+# time — see docs/postgres-consolidation.md for the runbook and ordering.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+spec:
+  # 2 instances: primary + hot standby. Survives one node loss and allows a
+  # Talos node drain with automatic failover. Replication is asynchronous
+  # (the CNPG default) and must stay that way: enabling synchronous quorum
+  # with only 2 instances means a standby outage stalls writes for every app
+  # on this cluster.
+  instances: 2
+
+  # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4-standard-trixie
+
+  primaryUpdateStrategy: unsupervised
+  primaryUpdateMethod: switchover
+
+  storage:
+    size: 50Gi
+    storageClass: longhorn-cnpg
+  walStorage:
+    size: 10Gi
+    storageClass: longhorn-cnpg
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: cnpg-superuser-secret
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      encoding: UTF8
+
+  postgresql:
+    parameters:
+      # ~11 apps eventually, Nextcloud alone holds ~30 connections.
+      max_connections: "200"
+      shared_buffers: "512MB"
+      effective_cache_size: "1536MB"
+      work_mem: "8MB"
+      maintenance_work_mem: "128MB"
+      max_slot_wal_keep_size: "4GB"
+      wal_keep_size: "1GB"
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      memory: 4Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  managed:
+    roles:
+      - name: forgejo
+        ensure: present
+        login: true
+        passwordSecret:
+          name: cnpg-role-forgejo-secret
+        comment: "Forgejo (tools namespace)"

--- a/kubernetes/apps/database/postgres/app/databases.yaml
+++ b/kubernetes/apps/database/postgres/app/databases.yaml
@@ -1,0 +1,15 @@
+---
+# One Database CR per application.
+# databaseReclaimPolicy: retain — a Flux prune or an accidental CR deletion must
+# never drop a real database. Dropping one is a deliberate, manual act.
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: forgejo
+spec:
+  cluster:
+    name: postgres
+  name: forgejo
+  owner: forgejo
+  encoding: UTF8
+  databaseReclaimPolicy: retain

--- a/kubernetes/apps/database/postgres/app/externalsecret.yaml
+++ b/kubernetes/apps/database/postgres/app/externalsecret.yaml
@@ -1,0 +1,47 @@
+---
+# Postgres superuser. CloudNativePG requires type kubernetes.io/basic-auth
+# with `username` and `password` keys.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-superuser
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: cnpg-superuser-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "postgres"
+        password: "{{ .superuser_password }}"
+  dataFrom:
+    - extract:
+        key: cnpg-postgres
+---
+# Per-application role credentials.
+# One ExternalSecret per role, all sourced from the same 1Password item.
+# Add a block here, a managed.roles[] entry in cluster.yaml, and a Database CR
+# in databases.yaml for each app migrated onto this cluster.
+# See docs/postgres-consolidation.md.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-role-forgejo
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: cnpg-role-forgejo-secret
+    template:
+      type: kubernetes.io/basic-auth
+      data:
+        username: "forgejo"
+        password: "{{ .forgejo_password }}"
+  dataFrom:
+    - extract:
+        key: cnpg-postgres

--- a/kubernetes/apps/database/postgres/app/kustomization.yaml
+++ b/kubernetes/apps/database/postgres/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./storageclass.yaml
+  - ./externalsecret.yaml
+  - ./cluster.yaml
+  - ./databases.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/database/postgres/app/prometheusrule.yaml
+++ b/kubernetes/apps/database/postgres/app/prometheusrule.yaml
@@ -1,0 +1,73 @@
+---
+# Discovered automatically: kube-prometheus-stack sets
+# ruleSelectorNilUsesHelmValues: false, so PrometheusRules in any namespace are
+# picked up. Alerts deliver to Mattermost via the alertmanager config secret.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cloudnative-pg
+spec:
+  groups:
+    - name: cloudnative-pg
+      rules:
+        - alert: CNPGCollectorDown
+          expr: cnpg_collector_up{namespace="database"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG metrics collector down on {{ $labels.pod }}"
+            description: >-
+              The CloudNativePG collector on {{ $labels.pod }} has been
+              unreachable for 5m. The instance is likely down.
+
+        - alert: CNPGNoStreamingReplica
+          # Evaluated on the primary only (in_recovery == 0).
+          expr: |
+            cnpg_pg_replication_streaming_replicas{namespace="database"} < 1
+            and on(pod) cnpg_pg_replication_in_recovery{namespace="database"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG primary {{ $labels.pod }} has no streaming replica"
+            description: >-
+              The cluster is running without a hot standby — a node loss now
+              means downtime for every app on this Postgres cluster.
+
+        - alert: CNPGReplicationLagHigh
+          expr: cnpg_pg_replication_lag{namespace="database"} > 300
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG replication lag {{ $value | humanizeDuration }} on {{ $labels.pod }}"
+            description: >-
+              Standby is more than 5 minutes behind the primary.
+
+        - alert: CNPGConnectionsHigh
+          expr: |
+            sum by (pod) (cnpg_backends_total{namespace="database"})
+              / on(pod) cnpg_pg_settings_setting{namespace="database", name="max_connections"}
+              > 0.8
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "CNPG {{ $labels.pod }} above 80% of max_connections"
+            description: >-
+              Consider raising max_connections or adding a Pooler (PgBouncer).
+
+        - alert: CNPGVolumeAlmostFull
+          expr: |
+            kubelet_volume_stats_available_bytes{namespace="database"}
+              / kubelet_volume_stats_capacity_bytes{namespace="database"}
+              < 0.15
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: "CNPG volume {{ $labels.persistentvolumeclaim }} is {{ $value | humanizePercentage }} free"
+            description: >-
+              A full WAL or data volume takes Postgres down. Expand the PVC —
+              longhorn-cnpg has allowVolumeExpansion enabled.

--- a/kubernetes/apps/database/postgres/app/storageclass.yaml
+++ b/kubernetes/apps/database/postgres/app/storageclass.yaml
@@ -1,0 +1,28 @@
+---
+# Longhorn StorageClass for CloudNativePG data and WAL volumes.
+#
+# numberOfReplicas: "1" is deliberate. CloudNativePG already replicates at the
+# Postgres layer (streaming replication between its instances), so the cluster's
+# default `longhorn` class (numberOfReplicas: 2) would give 2 CNPG instances x 2
+# Longhorn replicas = 4 physical copies of every byte, 4x write amplification on
+# the WAL, and 4x rebuild traffic — on 3 nodes that are also control-plane nodes.
+#
+# Unlike `longhorn-nobackup`, recurringJobSelector is deliberately OMITTED so
+# these volumes stay in the "default" recurring-job group and keep getting
+# snapshot-hourly / backup-daily / backup-weekly to the Synology. With no
+# block-level redundancy that off-box copy is the only thing underneath a disk
+# failure. Those block backups are crash-consistent only (Postgres replays WAL
+# on start); the nightly pg_dump in ../../db-backup is the authoritative
+# logical backup.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-cnpg
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  fromBackup: ""

--- a/kubernetes/apps/database/postgres/ks.yaml
+++ b/kubernetes/apps/database/postgres/ks.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postgres
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: external-secrets
+      namespace: security
+  interval: 1h
+  path: ./kubernetes/apps/database/postgres/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  # wait: true + a phase expression, so that an app declaring
+  # `dependsOn: postgres` genuinely means "the database is accepting
+  # connections", not merely "the Cluster object exists".
+  wait: true
+  healthChecks:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      name: postgres
+      namespace: database
+  healthCheckExprs:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      failed: status.phase.startsWith('Cluster in unrecoverable')
+      current: status.phase == 'Cluster in healthy state'


### PR DESCRIPTION
**PR 2 of 5** — Forgejo CI/CD + Postgres consolidation. Depends on #422.

Creates the shared CNPG `Cluster`, the `forgejo` role + `Database`, alerting, and the nightly logical backup.

### Storage: dedicated `longhorn-cnpg` class, `numberOfReplicas: "1"`

CNPG replicates at the Postgres layer. Leaving these volumes on the default `longhorn` class (2 replicas) would give **2 instances × 2 Longhorn replicas = 4 physical copies** of every byte, 4× WAL write amplification, and 4× rebuild traffic — on three nodes that are also control-plane nodes.

Unlike `longhorn-nobackup`, `recurringJobSelector` is **deliberately omitted** so these volumes stay in the `default` recurring-job group and keep shipping off-box to the Synology. With no block redundancy, that off-box copy is the only thing under a disk failure.

### `instances: 2`, async replication

Survives one node loss; allows a Talos drain with failover. **Synchronous quorum must never be enabled at this size** — a standby outage would stall writes for every app on the cluster.

### Backups are `pg_dump`, not barman

Barman-cloud needs object storage. This cluster has none, and Longhorn's only off-box target is NFS, which barman cannot use. Deploying MinIO to back up Postgres would invert the dependency graph — the backup target becomes another stateful workload on the same three nodes.

RPO is **24h**, accepted and documented. PITR is a later phase.

### Health gating

`postgres` Kustomization uses `healthCheckExprs` on `status.phase == 'Cluster in healthy state'`, so a downstream `dependsOn: postgres` means "the DB accepts connections", not "the object exists". PR3 relies on this.

`Database` CRs carry `databaseReclaimPolicy: retain` — a Flux prune must never drop a real database.

### Verification

```
kubectl -n database get cluster postgres -o wide            # 2/2, healthy
kubectl get sc longhorn-cnpg -o jsonpath='{.parameters.numberOfReplicas}'   # 1
kubectl -n database get database forgejo
kubectl create job --from=cronjob/db-backup-postgres manual -n database
```

### Rollback

`Cluster` deletion leaves the PVCs (retain policy). No application depends on this yet — Forgejo moves in PR3.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH