### PR TITLE
fix(database): pg_dumpall --dbname needs a connection string

### DIFF
--- a/kubernetes/apps/database/db-backup/app/cronjob-postgres.yaml
+++ b/kubernetes/apps/database/db-backup/app/cronjob-postgres.yaml
@@ -70,8 +70,12 @@ spec:
                   TS=$(date +%Y%m%d-%H%M%S)
 
                   echo "[$(date -u)] pg_dumpall --globals-only"
+                  # pg_dumpall's --dbname takes a CONNECTION STRING, not a bare
+                  # database name the way pg_dump's does. Passing `postgres`
+                  # fails with: missing "=" after "postgres" in connection info
+                  # string.
                   pg_dumpall --globals-only --no-role-passwords \
-                    --dbname=postgres > "/backups/globals-${TS}.sql"
+                    --dbname="dbname=postgres" > "/backups/globals-${TS}.sql"
                   ls -lh "/backups/globals-${TS}.sql"
 
                   DBS=$(psql --dbname=postgres -Atc \


### PR DESCRIPTION
Follow-up to #423, caught by running the backup job on demand instead of waiting for 01:20.

Every run failed with:

```
pg_dumpall: error: missing "=" after "postgres" in connection info string
```

Unlike `pg_dump`, **`pg_dumpall`'s `--dbname` takes a connection string**, not a bare database name — so `--dbname=postgres` is parsed as malformed conninfo. `dbname=postgres` is explicit and stays correct even if `PGDATABASE` is set in the environment later.

Verified in-cluster against the live cluster before and after:

```
# before
pg_dumpall --globals-only --no-role-passwords --dbname=postgres     -> exit 1, 0 lines
# after
pg_dumpall --globals-only --no-role-passwords --dbname=dbname=postgres -> exit 0, 43 lines
```

Per-database `pg_dump` was already fine (its `--dbname` does accept a bare name).

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH