### PR TITLE
feat(forgejo): move to Postgres, enable Actions and the container registry

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo/app/externalsecret.yaml
@@ -41,6 +41,12 @@ spec:
         security: "SECRET_KEY={{ .secret_key }}"
         # [server] section
         server: "LFS_JWT_SECRET={{ .lfs_jwt_secret }}"
+        # [database] section — password for the CNPG `forgejo` role. The rest of
+        # the section (DB_TYPE/HOST/NAME/USER) is declared in the HelmRelease.
+        # This value must stay in sync with the `forgejo_password` field on the
+        # 1Password `cnpg-postgres` item, which is what CNPG provisions the role
+        # with. Rotating one means rotating both.
+        database: "PASSWD={{ .db_password }}"
   dataFrom:
     - extract:
         key: forgejo

--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -23,10 +23,14 @@ spec:
         type: LoadBalancer
         port: 22
 
+    # 10Gi -> 50Gi for Actions job logs/artifacts and the container registry
+    # ([packages]). Expand ONLY `size` here: storageClass/accessModes are
+    # immutable, and changing one would make Helm try to recreate the PVC and
+    # fail the upgrade mid-flight. Longhorn cannot shrink a volume afterwards.
     persistence:
       enabled: true
       storageClass: longhorn
-      size: 10Gi
+      size: 50Gi
 
     gitea:
       admin:
@@ -37,6 +41,50 @@ spec:
             secretName: forgejo-config-secret
 
       config:
+        # PASSWD is injected via forgejo-config-secret (additionalConfigSources).
+        # Config sources are keyed by app.ini section name and the chart loads
+        # `additionals/` after `inlines/`, so the secret adds PASSWD to this
+        # same [database] section without clobbering the keys below.
+        database:
+          DB_TYPE: postgres
+          HOST: postgres-rw.database.svc.cluster.local:5432
+          NAME: forgejo
+          USER: forgejo
+          # In-cluster traffic on the Cilium pod network; CNPG's server cert is
+          # its own internal CA, which Forgejo would have to be taught to trust.
+          SSL_MODE: disable
+
+        actions:
+          ENABLED: true
+          # Where the RUNNER resolves bare `uses: actions/checkout@v4` from.
+          # `github` matches the wider ecosystem people copy-paste from; the
+          # runner has normal internet egress, so Forgejo being internal-only is
+          # irrelevant here. Forgejo's own actions remain usable fully-qualified:
+          #   uses: https://code.forgejo.org/actions/setup-node@v4
+          DEFAULT_ACTIONS_URL: github
+          LOG_RETENTION_DAYS: 30
+          LOG_COMPRESSION: zstd
+          ARTIFACT_RETENTION_DAYS: 30
+          ZOMBIE_TASK_TIMEOUT: 10m
+          ENDLESS_TASK_TIMEOUT: 3h
+          ABANDONED_JOB_TIMEOUT: 24h
+
+        # Container/package registry, served by Forgejo itself at
+        # https://git.${SECRET_DOMAIN}/v2/ — no extra route, hostname or cert.
+        # Storage is the local filesystem under /data (no S3 in this cluster),
+        # which is why the PVC above grew to 50Gi.
+        packages:
+          ENABLED: true
+
+        "cron.cleanup_actions":
+          ENABLED: true
+          SCHEDULE: "@midnight"
+
+        "cron.cleanup_packages":
+          ENABLED: true
+          SCHEDULE: "@midnight"
+          OLDER_THAN: 24h
+
         server:
           DOMAIN: "git.${SECRET_DOMAIN}"
           ROOT_URL: "https://git.${SECRET_DOMAIN}"
@@ -95,12 +143,14 @@ spec:
         # redirect URI https://git.${SECRET_DOMAIN}/user/oauth2/authentik/callback
         # (the path segment must match the auth source name above).
 
-    # Forgejo runs on its embedded SQLite database (DB_TYPE=sqlite3), which is
-    # appropriate for this single-user homelab instance. The forgejo-helm chart
-    # bundles no PostgreSQL subchart, so the previously-declared postgresql /
-    # postgresql-ha value blocks were inert (silently ignored) and never
-    # provisioned a database. Removed to end manifest-vs-reality drift.
-    # Application-consistent DB backups: see db-backup/app/cronjob-forgejo.yaml.
+    # Forgejo runs on the shared CloudNativePG cluster in the `database`
+    # namespace (migrated from embedded SQLite — SQLite on an RWO volume could
+    # not take the concurrent write load that Actions adds: job queue rows, step
+    # logs and artifact metadata). The forgejo-helm chart bundles no PostgreSQL
+    # subchart, so the connection is declared under gitea.config.database above.
+    # Backups: kubernetes/apps/database/db-backup dumps every database on the
+    # cluster nightly. Repo/LFS/package data on the PVC is covered separately by
+    # Longhorn's default recurring-job group.
 
     # Disable Redis cluster (use memory for single-pod)
     redis-cluster:
@@ -109,9 +159,11 @@ spec:
     strategy:
       type: Recreate
 
+    # Headroom for the Actions job queue, log ingestion and registry blob
+    # uploads, which all run in the Forgejo process.
     resources:
       requests:
         cpu: 200m
         memory: 512Mi
       limits:
-        memory: 1Gi
+        memory: 2Gi

--- a/kubernetes/apps/tools/forgejo/ks.yaml
+++ b/kubernetes/apps/tools/forgejo/ks.yaml
@@ -4,6 +4,12 @@ kind: Kustomization
 metadata:
   name: forgejo
 spec:
+  dependsOn:
+    # Forgejo's init container runs `gitea migrate` and hard-exits if the
+    # database is unreachable. The postgres Kustomization waits on the CNPG
+    # Cluster reporting a healthy phase, so this genuinely gates on a live DB.
+    - name: postgres
+      namespace: database
   interval: 1h
   path: ./kubernetes/apps/tools/forgejo/app
   postBuild:


### PR DESCRIPTION
**PR 3 of 5** — Forgejo CI/CD + Postgres consolidation. Depends on #423.

⚠️ **Requires a maintenance window.** The SQLite → Postgres data copy happens out-of-band between this landing and Forgejo serving traffic again.

### What changes

| | before | after |
|---|---|---|
| Database | SQLite on RWO Longhorn | CNPG `postgres-rw.database.svc` |
| PVC | 10Gi | 50Gi |
| Actions | off | on, 30d log + artifact retention |
| Registry | none | Forgejo `[packages]` at `/v2/` |

### Why SQLite had to go first

Actions adds concurrent writers — job queue rows, step logs, artifact metadata. SQLite on an RWO volume answers that with `database is locked`. It was also the only reason the existing backup job `kubectl exec`s into the running pod: nothing else could mount the volume. (Removing that hack + its namespace-wide `pods/exec` RBAC is PR5.)

### PVC expansion — `size` only

`storageClass`, `accessModes` and `volumeName` are **immutable**; editing one makes Helm try to recreate the PVC and fail the upgrade mid-flight. The chart's PVC is standalone with `helm.sh/resource-policy: keep`, so Helm patches size in place.

Expansion is **irreversible** (Longhorn cannot shrink), which is why 50Gi is deliberate rather than incremental.

### `DEFAULT_ACTIONS_URL: github`

Controls where the **runner** resolves a bare `uses: actions/checkout@v4` from. The runner has ordinary internet egress, so Forgejo being internal-only is irrelevant. Forgejo's own actions stay usable fully-qualified. Mirroring actions into Forgejo is a later hardening step.

### Registry needs no new route

Forgejo serves it at `/v2/` on the existing hostname, so the internal gateway's Let's Encrypt cert means Docker trusts it with no `--insecure-registry`.

### Password linkage

`db_password` on the 1P `forgejo` item must equal `forgejo_password` on `cnpg-postgres` — that's what CNPG provisions the role with. Both items carry a note so rotation touches both. Verified in-cluster: the role authenticates through `postgres-rw` with that exact value.

### Migration runbook

1. Pre-flight — CNPG healthy ✅, `Database forgejo` applied ✅, on-demand `forgejo dump` ✅, Longhorn snapshot ✅
2. `flux suspend ks forgejo`, scale to 0, checkpoint the SQLite WAL
3. Merge this PR, resume — Helm expands the PVC offline and the init container's `gitea migrate` builds the **complete empty PG schema**
4. Scale to 0; one-shot pgloader Job, `--with "data only"` + **`--with "reset sequences"`**
5. Scale up; `forgejo doctor check --all`
6. Acceptance: OIDC login · repos listed · clone SSH + HTTPS · **create a new repo and a new issue** (proves sequences) · `df -h /data` ~50G

**Correction to the plan:** the SQLite file is at `/data/forgejo.db`, not `/data/gitea/gitea.db`. It also has a ~4MB `-wal` companion that must be checkpointed on clean shutdown or recent commits are silently lost.

`reset sequences` is mandatory — without it every SERIAL stays at 1 and the first new insert throws duplicate-key. That is the #1 way this migration silently half-works, hence the explicit "create a repo and an issue" acceptance test.

### Rollback

Longhorn snapshot `pre-pg-migration-20260801-0726` + the `forgejo dump` tarball. SQLite file stays in place 30 days. Point of no return is deleting it.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH