### PR TITLE
feat(forgejo-runner): add Actions runner with a Docker-in-Docker sidecar

### DIFF
--- a/.taskfiles/validate/scripts/validate-security-context.sh
+++ b/.taskfiles/validate/scripts/validate-security-context.sh
@@ -35,6 +35,11 @@ KNOWN_UID_REQUIREMENTS=(
   "home-assistant/home-assistant:0"
   "metube:1000"
   "qdm12/gluetun:0"
+  # Docker-in-Docker for the Forgejo Actions runner: dockerd requires root
+  # and privileged: true. Job containers it spawns stay unprivileged.
+  "library/docker:0"
+  # act_runner image ships with a built-in 1000:1000 user.
+  "forgejo/runner:1000"
 )
 
 is_safe_for_65534() {

--- a/kubernetes/apps/tools/forgejo-runner/app/configmap.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/configmap.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forgejo-runner-config
+data:
+  config.yaml: |
+    log:
+      level: info
+
+    runner:
+      file: /data/.runner
+      # Concurrency comes from here, not from pod count: one pod running two
+      # jobs shares a single warm Docker image cache. Deliberately low — all
+      # three nodes in this cluster are control-plane nodes, so a runaway build
+      # competes with etcd and the apiserver.
+      capacity: 2
+      timeout: 1h
+      shutdown_timeout: 3h
+      insecure: false
+      fetch_timeout: 5s
+      fetch_interval: 2s
+      labels:
+        - "docker:docker://code.forgejo.org/oci/node:22-bookworm"
+        - "ubuntu-latest:docker://code.forgejo.org/oci/node:22-bookworm"
+        - "ubuntu-22.04:docker://code.forgejo.org/oci/node:22-bookworm"
+
+    cache:
+      # Cache server runs inside the runner container. Job containers live on
+      # dockerd's bridge network, which sits in this pod's network namespace,
+      # so auto-detection of the advertised host works. A cache failure degrades
+      # actions/cache but does not fail jobs.
+      enabled: true
+      dir: /data/cache
+      host: ""
+      port: 0
+
+    container:
+      network: bridge
+      # Job containers are UNPRIVILEGED. Only the dind sidecar is privileged.
+      privileged: false
+      # Caps a single job so a build cannot starve etcd or the other workloads
+      # sharing these nodes.
+      options: "--memory=4g --cpus=2"
+      workdir_parent: /workspace
+      # Deny workflows from bind-mounting arbitrary host paths into job
+      # containers. Widen deliberately if a workflow ever genuinely needs it.
+      valid_volumes: []
+      # "-" means: use the DOCKER_HOST env var (the dind sidecar over TLS).
+      # Never mount a node container socket here — Talos runs containerd, has
+      # no docker socket, and exposing one would be a node-takeover primitive.
+      docker_host: "-"
+      force_pull: false
+      force_rebuild: false
+
+    host:
+      workdir_parent: /data/workspace

--- a/kubernetes/apps/tools/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/externalsecret.yaml
@@ -1,0 +1,30 @@
+---
+# Runner registration secret.
+#
+# This is a pre-shared secret (openssl rand -hex 20) rather than the one-shot
+# token the Forgejo UI mints, so registration is reproducible from Git +
+# 1Password alone. Register it server-side once with:
+#
+#   kubectl -n tools exec -it deploy/forgejo -c forgejo -- \
+#     forgejo forgejo-cli actions register \
+#       --name k8s-runner-1 --scope '' --secret <the-40-hex-string>
+#
+# Re-running with the same secret is idempotent, so losing the runner's PVC
+# costs a pod restart rather than a manual re-registration.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-runner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: forgejo-runner-secret
+    template:
+      data:
+        RUNNER_TOKEN: "{{ .registration_token }}"
+  dataFrom:
+    - extract:
+        key: forgejo-runner

--- a/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
@@ -1,0 +1,262 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgejo-runner
+  interval: 1h
+  values:
+    controllers:
+      forgejo-runner:
+        replicas: 1
+        # Recreate: two RWO PVCs (runner state + docker image store) cannot be
+        # held by two pods at once.
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          # Native sidecar (restartPolicy: Always). Starts before the regular
+          # containers and keeps running, so dockerd is guaranteed to be up and
+          # to have generated its TLS material before act_runner connects —
+          # this removes the classic dind startup race.
+          dind:
+            image:
+              repository: docker.io/library/docker
+              tag: 29.7.0-dind
+            restartPolicy: Always
+            env:
+              # Generates a CA + server cert into /certs/server and a client
+              # cert into /certs/client, then serves TLS-only on :2376.
+              # Never blank this: doing so exposes an unauthenticated,
+              # root-equivalent Docker API on :2375, reachable by every pod in
+              # the cluster (no NetworkPolicy is enforced here).
+              DOCKER_TLS_CERTDIR: /certs
+              DOCKER_HOST: unix:///var/run/docker.sock
+            securityContext:
+              # dockerd genuinely requires this. No admission controller blocks
+              # it (PodSecurity is disabled at the apiserver); precedent exists
+              # in home-assistant and zwave-js-ui.
+              privileged: true
+              runAsUser: 0
+              runAsGroup: 0
+            probes:
+              liveness: &dindprobe
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["docker", "info"]
+                  initialDelaySeconds: 20
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 3
+              readiness: *dindprobe
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+                # Bounds a runaway build's writes to the node's EPHEMERAL
+                # partition (capped 50-95GB with grow: false on these Talos
+                # nodes). Image layers themselves live on the PVC below.
+                ephemeral-storage: 2Gi
+
+          register:
+            image:
+              repository: code.forgejo.org/forgejo/runner
+              tag: 12.13.2
+            dependsOn: dind
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                set -eu
+                if [ -f /data/.runner ]; then
+                  echo "Runner already registered; nothing to do."
+                  exit 0
+                fi
+                echo "Registering $${RUNNER_NAME} against $${FORGEJO_INSTANCE}"
+                /bin/forgejo-runner register --no-interactive \
+                  --config /config/config.yaml \
+                  --instance "$${FORGEJO_INSTANCE}" \
+                  --token "$${RUNNER_TOKEN}" \
+                  --name "$${RUNNER_NAME}" \
+                  --labels "docker:docker://code.forgejo.org/oci/node:22-bookworm"
+            env:
+              # Shell variables above are escaped $${VAR}: this Kustomization
+              # declares postBuild.substituteFrom, so a bare ${VAR} would be
+              # replaced by Flux with an empty string before the pod ever runs.
+              # ${SECRET_DOMAIN} below is intentionally UNescaped — that one
+              # Flux *should* substitute.
+              FORGEJO_INSTANCE: "https://git.${SECRET_DOMAIN}"
+              RUNNER_NAME: k8s-runner-1
+              RUNNER_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: forgejo-runner-secret
+                    key: RUNNER_TOKEN
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+        containers:
+          app:
+            image:
+              repository: code.forgejo.org/forgejo/runner
+              tag: 12.13.2
+            command:
+              ["/bin/forgejo-runner", "daemon", "--config", "/config/config.yaml"]
+            env:
+              # Containers in a pod share a network namespace, so localhost is
+              # the dind sidecar.
+              DOCKER_HOST: tcp://localhost:2376
+              DOCKER_TLS_VERIFY: "1"
+              DOCKER_CERT_PATH: /certs/client
+              TZ: America/Denver
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["/bin/sh", "-c", "test -f /data/.runner"]
+                  initialDelaySeconds: 30
+                  periodSeconds: 60
+                  failureThreshold: 3
+              readiness:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+                ephemeral-storage: 2Gi
+
+          # Keeps the docker image store from growing without bound. Without
+          # this the 50Gi PVC below fills and every build starts failing.
+          prune:
+            image:
+              repository: docker.io/library/docker
+              tag: 29.7.0-cli
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                while true; do
+                  sleep 86400
+                  docker system prune -af --filter "until=168h" || true
+                  docker builder prune -af --filter "until=168h" || true
+                done
+            env:
+              DOCKER_HOST: tcp://localhost:2376
+              DOCKER_TLS_VERIFY: "1"
+              DOCKER_CERT_PATH: /certs/client
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+        pod:
+          securityContext:
+            # Matches the runner image's built-in 1000:1000 user. The dind
+            # sidecar overrides this to root above.
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      # Runner registration state (.runner), act cache, host-mode workdir.
+      data:
+        type: persistentVolumeClaim
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+        size: 10Gi
+        advancedMounts:
+          forgejo-runner:
+            register:
+              - path: /data
+            app:
+              - path: /data
+
+      # Docker image layers and build cache.
+      #
+      # This MUST be a PVC, not an emptyDir. The Talos nodes cap their EPHEMERAL
+      # partition at 50-95GB with grow: false, so image layers on an emptyDir
+      # would push kubelet into DiskPressure and evict every workload on a node
+      # that is also a control-plane node. longhorn-nobackup because layers are
+      # 100% rebuildable and must not consume NAS backup capacity.
+      dind-storage:
+        type: persistentVolumeClaim
+        storageClass: longhorn-nobackup
+        accessMode: ReadWriteOnce
+        size: 50Gi
+        advancedMounts:
+          forgejo-runner:
+            dind:
+              - path: /var/lib/docker
+
+      # dockerd-generated TLS material. dind writes the whole tree; the clients
+      # get only the client cert, read-only.
+      certs:
+        type: emptyDir
+        advancedMounts:
+          forgejo-runner:
+            dind:
+              - path: /certs
+            app:
+              - path: /certs/client
+                subPath: client
+                readOnly: true
+            prune:
+              - path: /certs/client
+                subPath: client
+                readOnly: true
+
+      config:
+        type: configMap
+        name: forgejo-runner-config
+        advancedMounts:
+          forgejo-runner:
+            register:
+              - path: /config
+                readOnly: true
+            app:
+              - path: /config
+                readOnly: true
+
+      # Job working directories. emptyDir is correct here — short-lived, and
+      # bounded by the ephemeral-storage limits above.
+      workspace:
+        type: emptyDir
+        advancedMounts:
+          forgejo-runner:
+            app:
+              - path: /workspace
+
+    # No service and no route: the runner only makes outbound connections to
+    # Forgejo. Nothing needs to reach it.

--- a/kubernetes/apps/tools/forgejo-runner/app/kustomization.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./configmap.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/tools/forgejo-runner/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo-runner
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/forgejo-runner/ks.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo-runner
+spec:
+  dependsOn:
+    # The register init container talks to the Forgejo API and fails without it.
+    - name: forgejo
+  interval: 1h
+  path: ./kubernetes/apps/tools/forgejo-runner/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./db-backup/ks.yaml
   - ./forgejo/ks.yaml
+  - ./forgejo-runner/ks.yaml
   - ./shlink/ks.yaml
   - ./apprise/ks.yaml
   - ./artifacts/ks.yaml


### PR DESCRIPTION
**PR 4 of 5** — Forgejo CI/CD + Postgres consolidation. Depends on #425.

Deploys a single `act_runner` with `dockerd` alongside it so workflows can build and push container images. No official forgejo-runner Helm chart exists, so this uses bjw-s `app-template`, the repo standard.

### Pod shape

| container | image | role |
|---|---|---|
| `dind` (native sidecar) | `docker:29.7.0-dind` | privileged dockerd, TLS-only on :2376 |
| `register` (init) | `forgejo/runner:12.13.2` | idempotent — skips if `/data/.runner` exists |
| `app` | `forgejo/runner:12.13.2` | the runner daemon |
| `prune` | `docker:29.7.0-cli` | daily `docker system prune` |

**dockerd is a native sidecar** (`initContainers` + `restartPolicy: Always`), so it is started and has generated its TLS material *before* act_runner connects. That removes the classic dind startup race rather than relying on the runner's retry loop. Verified in the rendered output.

### ⚠️ `/var/lib/docker` is a PVC, not an emptyDir

**The most important line in this PR.** These Talos nodes cap `EPHEMERAL` at 50–95GB with `grow: false`. Image layers on an emptyDir would push kubelet into DiskPressure and evict every workload on a node that is *also a control-plane node*. `longhorn-nobackup` because layers are entirely rebuildable and must not consume NAS backup capacity. The prune sidecar keeps it bounded.

### Security posture

- **Docker API is TLS-only on :2376.** `DOCKER_TLS_CERTDIR` must never be unset — blanking it serves an unauthenticated, root-equivalent API on :2375, and with **no NetworkPolicy anywhere in this cluster** every pod could reach it.
- Only `dind` is privileged. **Job containers run unprivileged.**
- `valid_volumes: []` — workflows cannot bind-mount arbitrary host paths.
- `docker_host: "-"` — jobs use `DOCKER_HOST`. A node container socket is never mounted; on Talos that would be both impossible and a node-takeover primitive.
- Per-job cap `--memory=4g --cpus=2`.

### Registration

Uses a **pre-shared secret** from 1Password rather than the one-shot token the UI mints, so the runner's identity is reproducible from Git + 1Password alone and survives a PVC wipe. Already registered server-side:

```
kubectl -n tools exec deploy/forgejo -c forgejo -- \
  forgejo forgejo-cli actions register --name k8s-runner-1 --scope '' --secret <1P: forgejo-runner.registration_token>
```

### Concurrency

`capacity: 2` inside act_runner rather than more replicas, so both jobs share one warm image cache. Deliberately low — all three nodes are control-plane, so a runaway build competes with etcd and the apiserver. The real fix is a fourth non-control-plane node.

### Also

`validate-security-context.sh` gains `library/docker:0` and `forgejo/runner:1000` to `KNOWN_UID_REQUIREMENTS`, keeping that validator at its clean baseline.

### Verification

```
kubectl -n tools logs deploy/forgejo-runner -c app --tail=100     # runner online
kubectl -n tools exec deploy/forgejo-runner -c dind -- df -h /var/lib/docker
kubectl get nodes -o json | jq '.items[].status.conditions[]|select(.type=="DiskPressure")'
```

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH