### PR TITLE
fix(forgejo-runner): use create-runner-file, not register

### DIFF
--- a/kubernetes/apps/tools/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/externalsecret.yaml
@@ -24,7 +24,11 @@ spec:
     name: forgejo-runner-secret
     template:
       data:
-        RUNNER_TOKEN: "{{ .registration_token }}"
+        # Consumed by `forgejo-runner create-runner-file --secret`. This is a
+        # pre-shared secret, NOT the one-shot registration token the web UI
+        # mints — `forgejo-runner register --token` rejects it with
+        # "runner registration token not found".
+        RUNNER_SECRET: "{{ .registration_token }}"
   dataFrom:
     - extract:
         key: forgejo-runner

--- a/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
@@ -79,13 +79,20 @@ spec:
                   echo "Runner already registered; nothing to do."
                   exit 0
                 fi
-                echo "Registering $${RUNNER_NAME} against $${FORGEJO_INSTANCE}"
-                /bin/forgejo-runner register --no-interactive \
+                echo "Creating runner file for $${RUNNER_NAME} against $${FORGEJO_INSTANCE}"
+                # create-runner-file, NOT `register`. `register` consumes the
+                # one-shot registration token the web UI mints and fails against
+                # a pre-shared secret with "runner registration token not found".
+                # This subcommand is the counterpart to the server-side
+                # `forgejo-cli actions register --secret`, which is what we use so
+                # the runner's identity is reproducible from Git + 1Password.
+                # --connect proves the secret is accepted before the daemon starts.
+                /bin/forgejo-runner create-runner-file \
                   --config /config/config.yaml \
                   --instance "$${FORGEJO_INSTANCE}" \
-                  --token "$${RUNNER_TOKEN}" \
+                  --secret "$${RUNNER_SECRET}" \
                   --name "$${RUNNER_NAME}" \
-                  --labels "docker:docker://code.forgejo.org/oci/node:22-bookworm"
+                  --connect
             env:
               # Shell variables above are escaped $${VAR}: this Kustomization
               # declares postBuild.substituteFrom, so a bare ${VAR} would be
@@ -94,11 +101,13 @@ spec:
               # Flux *should* substitute.
               FORGEJO_INSTANCE: "https://git.${SECRET_DOMAIN}"
               RUNNER_NAME: k8s-runner-1
-              RUNNER_TOKEN:
+              # A pre-shared secret, not a registration token — the two are
+              # consumed by different subcommands. Named accordingly.
+              RUNNER_SECRET:
                 valueFrom:
                   secretKeyRef:
                     name: forgejo-runner-secret
-                    key: RUNNER_TOKEN
+                    key: RUNNER_SECRET
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
Follow-up to #426. The `register` init container crashlooped:

```
level=debug msg="Successfully pinged the Forgejo instance server"
level=error msg="poller: cannot register new runner" error="invalid_argument: runner registration token not found"
```

### Root cause

Two different registration flows, easy to conflate:

| flow | server side | client side |
|---|---|---|
| one-shot UI token | web UI mints a token | `forgejo-runner register --token` |
| **pre-shared secret** (ours) | `forgejo-cli actions register --secret` | **`forgejo-runner create-runner-file --secret`** |

We deliberately use the second — the runner's identity is reproducible from Git + 1Password and survives a PVC wipe. But the init container called `register --token`, which only understands the first, so the server correctly reported no such registration token.

`create-runner-file`'s own help text names the flag *"secret shared with the Forgejo instance via `forgejo-cli actions register`"* — exactly our flow.

**Connectivity was never the problem** — the logs show a successful ping immediately before the failure, which is what ruled out DNS/TLS/egress.

### Changes

- `register --token` → `create-runner-file --secret`
- `--connect` added, so the secret is proven acceptable *during init* rather than surfacing later as a quietly non-functional daemon
- `RUNNER_TOKEN` → `RUNNER_SECRET` in both the ExternalSecret and the pod env — conflating the two names is what made this easy to get wrong

The server-side runner row from #426 (`k8s-runner-1`, global scope) is unchanged and still valid.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH