### PR TITLE
fix(forgejo-runner): add a startupProbe to dind to close the cert race

### DIFF
--- a/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
@@ -55,6 +55,24 @@ spec:
                   timeoutSeconds: 10
                   failureThreshold: 3
               readiness: *dindprobe
+              # A native sidecar only guarantees dockerd has been STARTED before
+              # the regular containers run — not that it finished generating its
+              # TLS material. Without this, `app` raced dockerd and died with:
+              #   could not read CA certificate "/certs/client/ca.pem"
+              # A startupProbe is the one probe kubelet waits on before starting
+              # dependent containers, so it closes the race rather than relying
+              # on a crash and restart. dind's entrypoint writes the certs before
+              # dockerd listens, so a passing `docker info` implies certs exist.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["docker", "info"]
+                  initialDelaySeconds: 5
+                  periodSeconds: 3
+                  timeoutSeconds: 10
+                  failureThreshold: 40
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
Follow-up to #426/#427. Cosmetic in effect but worth fixing properly.

The runner container crashed exactly once on every fresh start:

```
level=info msg="Starting runner daemon"
Error: could not read CA certificate "/certs/client/ca.pem": open /certs/client/ca.pem: no such file or directory
```

### Why the native sidecar wasn't enough

Making dockerd a native sidecar (`initContainers` + `restartPolicy: Always`) guarantees it has been **started** before the regular containers run — but *not* that it has finished generating its TLS material. act_runner raced it, died, and only worked on the automatic restart.

**A `startupProbe` is the one probe kubelet waits on before starting dependent containers.** Readiness does not gate them. So this closes the race rather than relying on crash-and-retry.

dind's entrypoint writes the certificates *before* dockerd begins listening, so a passing `docker info` implies the certs already exist — which makes it a valid gate.

`failureThreshold: 40` at a 3s period allows ~2 minutes for a cold image pull before the sidecar is declared failed.

### Verified in the rendered output

```yaml
restartPolicy: Always
startupProbe:
  exec: {command: [docker, info]}
  failureThreshold: 40
  initialDelaySeconds: 5
  periodSeconds: 3
```

Expected result: `app` restart count stays at 0 through a fresh rollout.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH