### PR TITLE
fix(forgejo-runner): pin dind to 27.x so `uses:` actions work

### DIFF
--- a/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo-runner/app/helmrelease.yaml
@@ -25,7 +25,17 @@ spec:
           dind:
             image:
               repository: docker.io/library/docker
-              tag: 29.7.0-dind
+              # PINNED TO 27.x DELIBERATELY — do not let Renovate walk this to 28+.
+              # Docker 28 adopted os.Root-based archive extraction, which refuses
+              # to traverse a symlink during CopyToContainer. act stages actions at
+              # /var/run/act inside the job container, and /var/run is a symlink to
+              # /run in Debian-based images (including the default
+              # code.forgejo.org/oci/node:22-bookworm), so every `uses:` step died
+              # with:
+              #   statat var/run/act/actions/...: path escapes from parent
+              # Re-evaluate when act_runner stages actions somewhere other than
+              # /var/run, or upstream act works around the symlink.
+              tag: 27.5.1-dind
             restartPolicy: Always
             # dockerd listens on a UNIX SOCKET ONLY — no TCP listener exists.
             #
@@ -186,7 +196,8 @@ spec:
           prune:
             image:
               repository: docker.io/library/docker
-              tag: 29.7.0-cli
+              # Kept in step with the dind daemon above.
+              tag: 27.5.1-cli
             command: ["/bin/sh", "-c"]
             args:
               - |


### PR DESCRIPTION
Follow-up to #429. **Every `uses:` step was broken.**

```
copyDir: failed to copy content to container:
statat var/run/act/actions/29/<hash>: path escapes from parent
```

### Root cause

Docker 28 adopted **`os.Root`-based archive extraction**, which refuses to traverse a symlink while unpacking into a container.

act stages fetched actions under **`/var/run/act`**, and **`/var/run` is a symlink to `/run`** in Debian-based images — including the default job image `code.forgejo.org/oci/node:22-bookworm`. So the daemon rejected the copy, and `actions/checkout@v4` (and every other action) could never run.

Docker 27.5.1 uses the older extraction path and is unaffected.

### Scope — this is narrow

Everything else was **already proven working on 29.7.0**:

```
client=29.7.0 server=29.7.0      # job reached dockerd via the mounted socket
container ran 3.21.7             # docker run --rm alpine, inside a job
```

This is specifically about *unpacking an action into a container*, nothing else.

### Why pinned rather than floated

Pinned deliberately with the reasoning inline so a routine version bump doesn't silently reintroduce it. Renovate should not walk this to 28+.

**Trade-off, stated plainly:** this holds the daemon back from newer patch releases. Revisit when act stages actions somewhere other than `/var/run`, or upstream works around the symlink.

https://claude.ai/code/session_013NMxScmEukgGtfikSRqdxH