### PR TITLE
fix(forgejo): make Danger zone buttons readable in Catppuccin themes

### DIFF
--- a/kubernetes/apps/tools/forgejo/app/configmap.yaml
+++ b/kubernetes/apps/tools/forgejo/app/configmap.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forgejo-custom-templates
+data:
+  # Injected into <head> via Forgejo's `custom/header` template hook.
+  #
+  # The Catppuccin themes in /data/gitea/public/assets/css predate Forgejo's
+  # `--color-danger-bg` variable, so `.button.danger` (every button in a repo's
+  # "Danger zone": transfer, delete wiki, delete repo, archive) falls back to
+  # `--color-error-bg`. Catppuccin sets that to the *solid* accent red — the
+  # same value the button's text color resolves to — so the label renders red
+  # on red and is invisible. Give those themes a dark red-tinted surface so the
+  # red text has something to sit on. Scoped by attribute selector so Forgejo's
+  # own themes, which define the variable correctly, are untouched.
+  header.tmpl: |
+    <style>
+      html[data-theme^="catppuccin-"] {
+        --color-danger-bg: color-mix(in srgb, var(--color-red) 12%, var(--color-body));
+      }
+    </style>

--- a/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/forgejo/app/helmrelease.yaml
@@ -152,6 +152,21 @@ spec:
     # cluster nightly. Repo/LFS/package data on the PVC is covered separately by
     # Longhorn's default recurring-job group.
 
+    # Custom `header.tmpl` injected into <head> — patches a missing CSS variable
+    # in the Catppuccin themes. See configmap.yaml for the why. Mounted at the
+    # `custom/templates/custom` hook directory ($GITEA_CUSTOM is /data/gitea);
+    # that directory is otherwise unused, so shadowing it inside the PVC is
+    # safe. Runtime container only — the init containers do not read templates.
+    extraVolumes:
+      - name: custom-templates
+        configMap:
+          name: forgejo-custom-templates
+
+    extraContainerVolumeMounts:
+      - name: custom-templates
+        mountPath: /data/gitea/templates/custom
+        readOnly: true
+
     # Disable Redis cluster (use memory for single-pod)
     redis-cluster:
       enabled: false

--- a/kubernetes/apps/tools/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/tools/forgejo/app/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./externalsecret.yaml
+  - ./configmap.yaml
   - ./httproute.yaml
   - ./tcproute.yaml


### PR DESCRIPTION
The Catppuccin theme CSS in the Forgejo PVC predates Forgejo`s `--color-danger-bg` variable, so:

```css
.button.danger{background:var(--color-danger-bg, var(--color-error-bg));
               color:var(--color-thin-red, var(--color-red))}
```

falls back to `--color-error-bg` (`#f38ba8`) for the background and `--color-red` (`#f38ba8`) for the text — identical values. Every button in a repo`s Danger zone (transfer, delete wiki, delete repo, archive) rendered red-on-red and was invisible.

Forgejo`s own `forgejo-dark` theme defines `--color-danger-bg`, which is why only Catppuccin is affected. Only `.button.danger` uses it; the other `--color-thin-*` fallbacks resolve fine.

## Fix

- New `configmap.yaml` with a `header.tmpl` injected via Forgejo`s `custom/header` hook, defining `--color-danger-bg: color-mix(in srgb, var(--color-red) 12%, var(--color-body))`, scoped to `html[data-theme^="catppuccin-"]`.
- Mounted at `/data/gitea/templates/custom` via `extraVolumes` / `extraContainerVolumeMounts`.
- Reloader is already enabled on the pod, so the ConfigMap change restarts Forgejo.

Resulting contrast: ~7:1. Works for the latte variants too (`--color-body` is light there).

## Testing

- `task validate:flux` — 156 passed
- `task validate:static` — no findings in the changed files (pre-existing repo-wide lint noise unrelated to this change)

## Follow-up (not in this PR)

The ~70 Catppuccin theme CSS files live only in the PVC — they were copied in by hand and are not declared anywhere in this repo. Worth making declarative.

https://claude.ai/code/session_01TDLw5tjaQqN1FpSjZS9Fqs