### PR TITLE
fix(seerr): point public SecurityPolicy at the real HTTPRoute name

### DIFF
--- a/kubernetes/apps/media/seerr/app/securitypolicy-public.yaml
+++ b/kubernetes/apps/media/seerr/app/securitypolicy-public.yaml
@@ -10,7 +10,8 @@
 # Auth mode: external_identity_exception (see docs/architecture/authentication.md).
 # Empty extAuth needs no ReferenceGrant to authentik-server.
 #
-# Targets the rendered HTTPRoute `seerr-app` (bjw-s app-template route key `app`).
+# Targets the rendered HTTPRoute `seerr` — bjw-s app-template 5.x names the route
+# after the release when the route key is `app` (NOT `seerr-app`).
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
@@ -20,4 +21,4 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: seerr-app
+      name: seerr


### PR DESCRIPTION
## Problem
`requests.thegeekybits.com` is unreachable externally — it serves an Authentik "not found" page instead of Seerr's Plex login.

## Root cause
`securitypolicy-public.yaml` targets HTTPRoute **`seerr-app`**, but the rendered route in `media` is named **`seerr`** (app-template names it after the release for route key `app`). Unattached target → `kubectl get securitypolicy -n media seerr-app-public -o jsonpath='{.status}'` returns empty (no "Policy has been accepted"), so the gateway-level `envoy-external-default-auth` forward-auth still applies to the route.

Verified: `curl --resolve requests.thegeekybits.com:443:<cf-edge>` returns Authentik's branded 404, while the internal gateway 307s to `/login` correctly.

## Fix
Retarget the policy at `seerr` and correct the misleading comment.

https://claude.ai/code/session_01P3LJ2r7bVA7LpCEKEwdX22