### PR TITLE
feat(ai): add searxng as the crw search backend

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
   - ./librechat/ks.yaml
   - ./agentbox/ks.yaml
   - ./hermes-agent/ks.yaml
+  - ./searxng/ks.yaml

--- a/kubernetes/apps/ai/searxng/app/configmap.yaml
+++ b/kubernetes/apps/ai/searxng/app/configmap.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: searxng-config
+data:
+  settings.yml: |
+    # Read the documentation before extending the defaults:
+    # https://docs.searxng.org/admin/settings/
+    use_default_settings: true
+
+    general:
+      instance_name: "SearXNG"
+      donation_url: false
+      contact_url: false
+      enable_metrics: false
+
+    server:
+      # secret_key is injected via the SEARXNG_SECRET env var (ExternalSecret).
+      base_url: "https://searxng.${SECRET_DOMAIN}/"
+      # The limiter (bot detection) rejects the JSON API with 429 and needs a
+      # Valkey/Redis backend. This instance is internal-only, so keep it off.
+      limiter: false
+      public_instance: false
+      image_proxy: true
+      method: "GET"
+
+    search:
+      safe_search: 0
+      autocomplete: ""
+      default_lang: "en"
+      # "json" is required by the crw search backend. Upstream ships html only.
+      formats:
+        - html
+        - json
+
+    ui:
+      static_use_hash: true

--- a/kubernetes/apps/ai/searxng/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/searxng/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: searxng
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: searxng-secret
+    template:
+      data:
+        SEARXNG_SECRET: "{{ .secret_key }}"
+  data:
+    - secretKey: secret_key
+      remoteRef:
+        key: searxng
+        property: secret_key

--- a/kubernetes/apps/ai/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/searxng/app/helmrelease.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: searxng
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: searxng
+  interval: 1h
+  values:
+    controllers:
+      searxng:
+        containers:
+          app:
+            image:
+              repository: docker.io/searxng/searxng
+              tag: 2026.8.12-cdfdaa5a8
+            env:
+              # The entrypoint only chowns when running as root. We run as 977,
+              # so skip the check and keep the warning out of the logs.
+              FORCE_OWNERSHIP: "false"
+              SEARXNG_SETTINGS_PATH: /etc/searxng/settings.yml
+            envFrom:
+              - secretRef:
+                  name: searxng-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: 8080
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 977
+        runAsGroup: 977
+        fsGroup: 977
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: searxng
+        ports:
+          http:
+            port: 8080
+
+    persistence:
+      config:
+        type: configMap
+        name: searxng-config
+        globalMounts:
+          - path: /etc/searxng/settings.yml
+            subPath: settings.yml
+            readOnly: true
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /var/cache/searxng
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+
+    route:
+      app:
+        hostnames: ["searxng.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: searxng
+                port: 8080

--- a/kubernetes/apps/ai/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/ai/searxng/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/searxng/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/searxng/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: searxng
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/searxng/ks.yaml
+++ b/kubernetes/apps/ai/searxng/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: searxng
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/ai/searxng/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: ai
+  wait: false


### PR DESCRIPTION
Self-hosted metasearch instance in the `ai` namespace. Backs the `crw` CLI's `search` verb (the binary was installed locally but had no backend); also usable by open-webui/librechat web search.

Non-obvious bits:
- `search.formats` must include `json` — upstream ships html only, which is what makes the API 403.
- `limiter: false` — the bot limiter 429s the JSON API and would otherwise need a valkey backend.
- `secret_key` comes from the `SEARXNG_SECRET` env var (1P item `searxng`), so the settings ConfigMap can stay read-only. The entrypoint only templates settings.yml when it is absent.
- Runs as 977 (the image's own uid) with a read-only rootfs; emptyDirs for the cache and tmp paths.

Validated: `flux-local test` 158 passed, plus routes / substitutions / secret-keys / images / security-ctx. Pre-existing failures elsewhere (authentik, qbittorrent, 28 stale tags) are untouched.

https://claude.ai/code/session_012w1Ddst7UCYNmTtGqBQGFJ