### PR TITLE
feat(matrix-media-relay): send Matrix images with an inline caption

### DIFF
--- a/docs/matrix-webhooks.md
+++ b/docs/matrix-webhooks.md
@@ -44,6 +44,66 @@ runs with `readOnlyRootFilesystem: true` and read-only secret mounts.
 - A malformed registration file **crash-loops Synapse**. Roll back the two
   synapse files if that happens.
 
+## Images: matrix-media-relay
+
+Hookshot **cannot send images**. Its generic-webhook result type is text/html
+only (no `url`/`info`/`file`), and transformation functions run in QuickJS with
+no network, so they cannot upload. Separately, Element destroys any `<img>`
+whose `src` is not an `mxc://` URI:
+
+```js
+// element-web apps/web/src/Linkify.ts
+if (!src.startsWith("mxc://")) { return { tagName, attribs: {} }; }
+```
+
+So a remote poster URL can never render, by any combination of webhook JSON.
+
+Apprise *can* upload (`POST /_matrix/media/v3/upload` → `m.image`), but sends the
+image and the text as **two separate events** with no caption support. For a
+single event carrying both, `kubernetes/apps/tools/matrix-media-relay/` fetches
+the artwork, uploads it, and sends one `m.image` with an MSC2530 caption.
+
+The caption only works when `filename` differs from `body` — if they match,
+clients render no caption at all.
+
+**Auth:** the relay uses **hookshot's appservice token** to masquerade as the
+same `@_webhooks_*` ghost that posts the text-only messages, so notifications
+keep one consistent sender. This needs no second appservice registration and
+therefore no Synapse restart. Consequence: rotating hookshot's `as_token`
+rotates the relay's too. `AS_TOKEN` and `TAUTULLI_API_KEY` are referenced
+directly from the `hookshot` and `tautulli` 1Password items rather than copied,
+so there is no drift.
+
+The relay is stdlib-only Python mounted from a ConfigMap into a stock `python`
+image — no image build, no registry, and Renovate still tracks the base tag.
+
+### Wiring Tautulli to it
+
+Tautulli's `/pms_image_proxy` requires a **web session**; only the `/api/v2`
+command form accepts an API key, which is what the relay calls. `{poster_url}`
+is empty unless notification image hosting is enabled, so pass the library path
+built from `{rating_key}` instead — the bare `/thumb` path resolves fine.
+
+Webhook URL `http://matrix-media-relay.tools.svc.cluster.local:8080/notify`, POST.
+
+JSON Headers:
+
+```json
+{"Authorization": "Bearer <auth_token from 1P matrix-media-relay>", "Content-Type": "application/json"}
+```
+
+JSON Data (Recently Added):
+
+```json
+{"room": "!oczWlBAHrRRoVjTndB:matrix.${SECRET_DOMAIN}",
+ "img": "/library/metadata/{rating_key}/thumb",
+ "text": "New {media_type!c} Available\n\n<movie>{title} ({year}) [{video_full_resolution}] - Runtime: {duration}\n{imdb_url}</movie><episode>{show_name} - S{season_num00}E{episode_num00} - {episode_name} [{video_full_resolution}]\n{thetvdb_url}</episode>",
+ "html": "<b>New {media_type!c} Available</b><br><movie><a href=\"{imdb_url}\">{title}</a> ({year}) <span data-mx-color=\"#888888\">[{video_full_resolution}] &middot; {duration}</span></movie><episode><a href=\"{thetvdb_url}\">{show_name}</a> - S{season_num00}E{episode_num00}<br>{episode_name}</episode>"}
+```
+
+Omit `img` and the relay sends a plain `m.notice` instead, so it degrades
+gracefully for sources with no artwork.
+
 ## Known-good noise
 
 Hookshot logs this on **every** start:

--- a/kubernetes/apps/tools/kustomization.yaml
+++ b/kubernetes/apps/tools/kustomization.yaml
@@ -28,5 +28,6 @@ resources:
   - ./mas/ks.yaml
   - ./element/ks.yaml
   - ./hookshot/ks.yaml
+  - ./matrix-media-relay/ks.yaml
   # - ./syncthing/ks.yaml
   # - ./kms/ks.yaml ## Disabling for now, likely to archive later

--- a/kubernetes/apps/tools/matrix-media-relay/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: matrix-media-relay
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-store
+  target:
+    name: matrix-media-relay-secret
+  # Pulled from the owning items rather than copied into a new one, so rotating
+  # hookshot's or tautulli's credentials propagates here with no second edit.
+  data:
+    # Hookshot's appservice token. Synapse lets an AS token masquerade as any
+    # user in its exclusive namespace, so the relay posts as the same
+    # @_webhooks_* ghost hookshot uses -- no second appservice registration,
+    # and no Synapse restart.
+    - secretKey: AS_TOKEN
+      remoteRef:
+        key: hookshot
+        property: as_token
+    # Tautulli's /pms_image_proxy requires a web session; only the /api/v2
+    # command form accepts an API key, which is what the relay calls.
+    - secretKey: TAUTULLI_API_KEY
+      remoteRef:
+        key: tautulli
+        property: api_key
+    # Shared secret Tautulli sends as `Authorization: Bearer`, so the relay is
+    # not an open post-to-any-room endpoint on the internal network.
+    - secretKey: AUTH_TOKEN
+      remoteRef:
+        key: matrix-media-relay
+        property: auth_token

--- a/kubernetes/apps/tools/matrix-media-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matrix-media-relay
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: matrix-media-relay
+  interval: 1h
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: python
+              tag: 3.13-slim
+            command: ["python", "-u", "/app/relay.py"]
+            env:
+              TZ: America/New_York
+              PORT: &port 8080
+              SYNAPSE_URL: http://synapse-main.tools.svc.cluster.local:8008
+              TAUTULLI_URL: http://tautulli.media.svc.cluster.local:8181
+              SENDER: "@_webhooks_plex:matrix.${SECRET_DOMAIN}"
+            envFrom:
+              - secretRef:
+                  name: matrix-media-relay-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+
+    persistence:
+      src:
+        type: configMap
+        name: matrix-media-relay-src
+        advancedMounts:
+          main:
+            app:
+              - path: /app/relay.py
+                subPath: relay.py
+                readOnly: true
+
+    # Internal only. Tautulli reaches it in-cluster; the route is for testing.
+    route:
+      app:
+        hostnames: ["matrix-media-relay.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: matrix-media-relay
+                port: *port

--- a/kubernetes/apps/tools/matrix-media-relay/app/kustomization.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/app/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+
+# The relay is stdlib-only Python mounted into a stock python image, so there is
+# no image to build or registry to publish to. disableNameSuffixHash keeps the
+# name stable for the helmrelease reference; reloader restarts the pod on change.
+configMapGenerator:
+  - name: matrix-media-relay-src
+    files:
+      - relay.py
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/tools/matrix-media-relay/app/ocirepository.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: matrix-media-relay
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/tools/matrix-media-relay/app/relay.py
+++ b/kubernetes/apps/tools/matrix-media-relay/app/relay.py
@@ -1,0 +1,170 @@
+"""Post a single Matrix m.image event carrying its own caption.
+
+Hookshot's generic webhooks cannot send images: its transformation result type
+is text/html only, and the QuickJS sandbox has no network. Apprise can upload,
+but emits the image and the text as two separate events. This relay exists for
+the one case neither covers -- a single event with the artwork and the text
+together (MSC2530 caption), which is what Element renders as one card.
+
+Fetches the poster from Tautulli's API, uploads it to the Synapse media repo,
+and sends one m.image. Authenticates with hookshot's appservice token so it can
+masquerade as the same @_webhooks_* ghost that posts the text-only messages --
+no second appservice registration, so no Synapse restart.
+
+Stdlib only, so it runs on a stock python image with no build step.
+"""
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+SYNAPSE_URL = os.environ.get("SYNAPSE_URL", "http://synapse-main.tools.svc.cluster.local:8008")
+AS_TOKEN = os.environ["AS_TOKEN"]
+SENDER = os.environ["SENDER"]
+DEFAULT_ROOM = os.environ.get("DEFAULT_ROOM", "")
+TAUTULLI_URL = os.environ.get("TAUTULLI_URL", "http://tautulli.media.svc.cluster.local:8181")
+TAUTULLI_API_KEY = os.environ.get("TAUTULLI_API_KEY", "")
+AUTH_TOKEN = os.environ.get("AUTH_TOKEN", "")
+PORT = int(os.environ.get("PORT", "8080"))
+TIMEOUT = int(os.environ.get("HTTP_TIMEOUT", "30"))
+MAX_IMAGE_BYTES = int(os.environ.get("MAX_IMAGE_BYTES", str(10 * 1024 * 1024)))
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("relay")
+
+
+def _image_size(data):
+    """(width, height) for PNG/JPEG, or (None, None). Only a rendering hint --
+    without it Element reflows the timeline while the image loads."""
+    try:
+        if data[:8] == b"\x89PNG\r\n\x1a\n":
+            return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+        if data[:2] == b"\xff\xd8":
+            i = 2
+            while i < len(data) - 9:
+                if data[i] != 0xFF:
+                    i += 1
+                    continue
+                marker = data[i + 1]
+                # SOF0-SOF15, excluding the non-frame markers DHT/JPG/DAC
+                if 0xC0 <= marker <= 0xCF and marker not in (0xC4, 0xC8, 0xCC):
+                    return (int.from_bytes(data[i + 7:i + 9], "big"),
+                            int.from_bytes(data[i + 5:i + 7], "big"))
+                i += 2 + int.from_bytes(data[i + 2:i + 4], "big")
+    except Exception:
+        log.warning("could not determine image dimensions", exc_info=True)
+    return None, None
+
+
+def _matrix(method, path, body=None, content_type="application/json", raw=False):
+    sep = "&" if "?" in path else "?"
+    url = SYNAPSE_URL + path + sep + "user_id=" + urllib.parse.quote(SENDER)
+    data = body if raw else (json.dumps(body).encode() if body is not None else None)
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={"Authorization": "Bearer " + AS_TOKEN, "Content-Type": content_type},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return json.load(resp)
+
+
+def fetch_poster(img):
+    """Tautulli's /pms_image_proxy requires a web session; only the /api/v2
+    command form accepts the API key."""
+    if not TAUTULLI_API_KEY:
+        raise ValueError("img supplied but TAUTULLI_API_KEY is not set")
+    url = TAUTULLI_URL + "/api/v2?" + urllib.parse.urlencode({
+        "apikey": TAUTULLI_API_KEY, "cmd": "pms_image_proxy",
+        "img": img, "width": 400, "height": 600, "fallback": "poster",
+    })
+    with urllib.request.urlopen(url, timeout=TIMEOUT) as resp:
+        ctype = (resp.headers.get("Content-Type") or "").split(";")[0].strip()
+        data = resp.read(MAX_IMAGE_BYTES + 1)
+    if not ctype.startswith("image/"):
+        # Tautulli answers an unauthenticated request with its login page, 200 OK.
+        raise ValueError("Tautulli returned %s, not an image (check the API key)" % ctype)
+    if len(data) > MAX_IMAGE_BYTES:
+        raise ValueError("poster exceeds MAX_IMAGE_BYTES (%d)" % MAX_IMAGE_BYTES)
+    return data, ctype
+
+
+def send(payload):
+    room = payload.get("room") or DEFAULT_ROOM
+    if not room:
+        raise ValueError("no room supplied and DEFAULT_ROOM is unset")
+    text = payload.get("text") or ""
+    html = payload.get("html")
+    img = payload.get("img")
+
+    if img:
+        data, ctype = fetch_poster(img)
+        filename = payload.get("filename") or ("poster." + (ctype.split("/")[-1] or "jpg"))
+        mxc = _matrix("POST", "/_matrix/media/v3/upload?filename=" + urllib.parse.quote(filename),
+                      data, ctype, raw=True)["content_uri"]
+        width, height = _image_size(data)
+        info = {"mimetype": ctype, "size": len(data)}
+        if width and height:
+            info.update({"w": width, "h": height})
+        # filename distinct from body is what marks body as a caption (MSC2530);
+        # if they match, clients render no caption at all.
+        content = {"msgtype": "m.image", "url": mxc, "filename": filename,
+                   "body": text or filename, "info": info}
+    else:
+        content = {"msgtype": "m.notice", "body": text}
+
+    if html:
+        content.update({"format": "org.matrix.custom.html", "formatted_body": html})
+
+    path = "/_matrix/client/v3/rooms/%s/send/m.room.message/%s" % (
+        urllib.parse.quote(room), "relay-%d" % (time.time() * 1000))
+    return _matrix("PUT", path, content)["event_id"]
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _reply(self, code, body):
+        raw = json.dumps(body).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):
+        if self.path in ("/healthz", "/live", "/ready"):
+            return self._reply(200, {"ok": True})
+        self._reply(404, {"error": "not found"})
+
+    def do_POST(self):
+        if self.path.split("?")[0] != "/notify":
+            return self._reply(404, {"error": "not found"})
+        if AUTH_TOKEN and self.headers.get("Authorization") != "Bearer " + AUTH_TOKEN:
+            return self._reply(401, {"error": "unauthorized"})
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            if length <= 0:
+                raise ValueError("empty body")
+            payload = json.loads(self.rfile.read(length))
+        except Exception as exc:
+            log.warning("bad request: %s", exc)
+            return self._reply(400, {"error": str(exc)})
+        try:
+            event_id = send(payload)
+        except Exception as exc:
+            log.exception("send failed")
+            return self._reply(502, {"error": str(exc)})
+        log.info("sent %s", event_id)
+        self._reply(200, {"event_id": event_id})
+
+    def log_message(self, fmt, *args):
+        log.info("%s - %s", self.address_string(), fmt % args)
+
+
+if __name__ == "__main__":
+    log.info("listening on :%d as %s", PORT, SENDER)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()

--- a/kubernetes/apps/tools/matrix-media-relay/ks.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: matrix-media-relay
+spec:
+  # Uses hookshot's appservice token to masquerade as its @_webhooks_* ghosts,
+  # so the registration secret (owned by synapse) must exist first.
+  dependsOn:
+    - name: synapse
+  interval: 1h
+  path: ./kubernetes/apps/tools/matrix-media-relay/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: tools
+  wait: false


### PR DESCRIPTION
Stacked on #482 (docs), which this builds on. Retargets to `main` automatically when that merges.

### Why this exists

**Hookshot cannot send images.** Its generic-webhook result type is text/html only — no `url`, no `info`, no `file` — and transformation functions run in QuickJS with no network, so they can't upload either. Element compounds it by destroying any `<img>` whose `src` isn't `mxc://`:

```js
// element-web apps/web/src/Linkify.ts
if (!src.startsWith("mxc://")) { return { tagName, attribs: {} }; }
```

So a remote poster URL can never render, by any combination of webhook JSON.

**Apprise can upload** (`POST /_matrix/media/v3/upload` → `m.image`) but emits the image and the text as **two separate events**, with no caption support. This relay covers what neither does: one `m.image` carrying artwork and text together as an MSC2530 caption, which Element renders as a single card.

### Design notes

- **Auth via hookshot's appservice token**, masquerading as the same `@_webhooks_*` ghost that posts the text-only messages — so notifications keep one consistent sender. Deliberately avoids a second appservice registration and therefore a Synapse restart. Tradeoff: rotating hookshot's `as_token` rotates this too.
- `AS_TOKEN` and `TAUTULLI_API_KEY` are **referenced from the existing `hookshot` and `tautulli` 1Password items**, not copied into a new one — no drift.
- **Stdlib-only Python from a ConfigMap** into a stock `python` image: no image build, no registry, Renovate still tracks the base tag.
- `AUTH_TOKEN` bearer check so it isn't an open post-to-any-room endpoint on the internal network.
- Omit `img` and it sends a plain `m.notice`, so it degrades gracefully for sources with no artwork.

Two Tautulli specifics are baked in because they cost time to find: `/pms_image_proxy` requires a **web session** and ignores API keys (it answers unauthenticated requests with its login page, `200 OK`), so the relay calls the `/api/v2` command form; and `{poster_url}` is empty unless notification image hosting is enabled, so the caller passes a path built from `{rating_key}`.

### Verified end-to-end

Ran the exact upload + send flow against the live cluster using the most recent movie in the library — poster uploaded to `mxc://`, single `m.image` delivered to the Plex room, caption rendered inline. Image-dimension parsing unit-checked against that poster (`400x600`).

`validate:flux` 162/162 · `validate:routes` pass · `validate:secret-keys` pass · image tag confirmed.

### ⚠️ Before merging

Create 1Password item **`matrix-media-relay`** in `homeops` with a single concealed field `auth_token` (`openssl rand -hex 32`). Without it the ExternalSecret won't sync and the pod won't start. It does **not** affect Synapse or Hookshot — no repeat of the #481 outage.

Then repoint Tautulli's webhook at `http://matrix-media-relay.tools.svc.cluster.local:8080/notify`; the JSON Headers and JSON Data are in `docs/matrix-webhooks.md`.

https://claude.ai/code/session_01L7Np3o3iBEarPShpk8ySUV