### PR TITLE
fix(matrix-media-relay): actually mount the avatar ConfigMap

### DIFF
--- a/kubernetes/apps/tools/matrix-media-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/matrix-media-relay/app/helmrelease.yaml
@@ -95,6 +95,18 @@ spec:
               - path: /app/relay.py
                 subPath: relay.py
                 readOnly: true
+      # Ghost avatars, referenced by "avatar" in PROFILES above. Without this
+      # mount the relay logs that the file is unreadable and skips applying the
+      # avatar -- notifications still send, so the omission is quiet.
+      avatars:
+        type: configMap
+        name: matrix-media-relay-avatars
+        advancedMounts:
+          main:
+            app:
+              - path: /app/avatars/avatar-plex.png
+                subPath: avatar-plex.png
+                readOnly: true
 
     # Internal only. Tautulli reaches it in-cluster; the route is for testing.
     route:


### PR DESCRIPTION
#529 added the avatar ConfigMap and the `"avatar"` key in `PROFILES`, but **never mounted the volume**. The relay looks for `/app/avatars/avatar-plex.png`, doesn't find it, and skips.

### How it slipped through

I applied that edit with an **unasserted** `str.replace` anchored on a `registration:` persistence entry — which exists in *Hookshot's* HelmRelease, not the relay's. It matched nothing and silently did nothing. The `assert` that would have caught it was on the neighbouring edit, not this one.

It then survived review because the failure mode is deliberately quiet: a missing avatar file logs a warning and is skipped so the notification still sends. Nothing was broken — notifications kept working with the avatar applied by hand earlier — and no test asserts the mount exists.

### Verified

Rendered the chart and confirmed both volumes (`matrix-media-relay-src`, `matrix-media-relay-avatars`) and both mountPaths (`/app/relay.py`, `/app/avatars/avatar-plex.png`) are present.

`validate:flux` 162/162.

Note this is the second issue from #529 — the first being the `.sourceignore` PNG exclusion in #530. Neither is catchable by current CI, since `kustomize build` reads the working tree and nothing asserts on rendered mounts.

https://claude.ai/code/session_01L7Np3o3iBEarPShpk8ySUV