### PR TITLE
fix(mas): serve the legacy /login endpoints on the Synapse host

### DIFF
--- a/kubernetes/apps/tools/mas/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/mas/app/helmrelease.yaml
@@ -134,3 +134,37 @@ spec:
           - backendRefs:
               - name: mas-main
                 port: 8080
+      # MAS's compatibility layer, mounted on the Synapse client-API host.
+      # Synapse delegates auth to MAS and therefore answers M_UNRECOGNIZED on
+      # the legacy /login endpoints; clients that do not speak native OIDC
+      # (MSC2965) — FluffyChat, most mobile clients — read /login to discover
+      # flows and so offer no way to sign in. These rules hand login/logout/
+      # refresh to MAS instead, which advertises m.login.sso. Gateway API has
+      # no mid-path wildcard, so each client-API version is listed; the longer
+      # PathPrefix beats Synapse's catch-all at the gateway.
+      compat:
+        hostnames: ["synapse.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /_matrix/client/r0/login
+              - path:
+                  type: PathPrefix
+                  value: /_matrix/client/v3/login
+              - path:
+                  type: PathPrefix
+                  value: /_matrix/client/r0/logout
+              - path:
+                  type: PathPrefix
+                  value: /_matrix/client/v3/logout
+              - path:
+                  type: PathPrefix
+                  value: /_matrix/client/v3/refresh
+            backendRefs:
+              - name: mas-main
+                port: 8080

--- a/kubernetes/apps/tools/synapse/app/helmrelease.yaml
+++ b/kubernetes/apps/tools/synapse/app/helmrelease.yaml
@@ -182,6 +182,8 @@ spec:
             namespace: network
             sectionName: https
         rules:
+          # The legacy login endpoints on this host are served by MAS, not
+          # Synapse — see the `compat` route in the mas HelmRelease.
           - backendRefs:
               - name: synapse-main
                 port: 8008


### PR DESCRIPTION
## Problem

FluffyChat (and any other client that does not speak native OIDC) shows no way to sign in to the homeserver — no password field, no SSO button.

Synapse delegates auth to MAS, so it answers `M_UNRECOGNIZED` on the legacy login API:

```
$ curl -s https://synapse.<domain>/_matrix/client/v3/login
{"errcode":"M_UNRECOGNIZED","error":"Unrecognized request"}
```

Element is unaffected: it reads `/.well-known/matrix/client` and `auth_metadata` and does native OIDC (MSC2965). FluffyChat only reads `/login` to discover flows, gets a 404, and renders nothing — see [krille-chan/fluffychat#732](https://github.com/krille-chan/fluffychat/issues/732).

MAS already serves the compatibility layer correctly, just not on the Synapse hostname:

```
$ curl -s https://mas.<domain>/_matrix/client/v3/login
{"flows":[{"type":"m.login.sso","oauth_aware_preferred":true,...},{"type":"m.login.token"}]}
```

## Fix

Add a `compat` route to the mas HelmRelease bound to the Synapse client-API hostname, handing `login` / `logout` / `refresh` to MAS. This is the reverse-proxy step from the [MAS homeserver setup docs](https://element-hq.github.io/matrix-authentication-service/setup/homeserver.html), expressed as Gateway API rules. Gateway API has no mid-path wildcard, so each client-API version is listed; the longer PathPrefix beats Synapse's catch-all at the gateway.

The rules live in the `mas` release rather than `synapse` so the backendRef stays in-release and `validate:routes` can verify it statically.

No exposure change — both routes are `envoy-internal`.

## Validation

- `task validate:flux` — 162 passed
- `task validate:routes` — passed
- route-class security validator — passed, external routes unchanged

`task validate:static` still fails on pre-existing yamllint errors in the media apps; nothing in `synapse` or `mas` is flagged.

## Verify after reconcile

```
curl -s https://synapse.<domain>/_matrix/client/v3/login
```

Should return the `m.login.sso` flow list. FluffyChat then shows an SSO button → MAS → Authentik.

https://claude.ai/code/session_01Go9Cg3PiWk9VMRUWqoqkBa