### PR TITLE
fix(element): disable the unreachable integration manager

### DIFF
--- a/kubernetes/apps/tools/element/app/configmap.yaml
+++ b/kubernetes/apps/tools/element/app/configmap.yaml
@@ -9,6 +9,14 @@ data:
   # Custom homeserver URLs and guests are disabled — this is a single-server,
   # internal-only deployment.
   #
+  # The integration manager is disabled outright. Element defaults to the
+  # public Scalar (scalar.vector.im), which authenticates by calling the
+  # homeserver's federation OpenID endpoint — unreachable here, since Synapse
+  # is internal-only with federation off (federation_domain_whitelist: []).
+  # "Add extensions" therefore always failed with "cannot connect to
+  # integration manager"; empty integrations_* URLs hide the button instead.
+  # Widgets still work via /addwidget, and bots/bridges via direct invite.
+  #
   # Theme: Catppuccin (https://github.com/catppuccin/element), Blue accent.
   # Registered as two selectable custom themes (Mocha = dark default, Latte =
   # light) via setting_defaults.custom_themes rather than a per-user Labs URL,
@@ -23,6 +31,9 @@ data:
       },
       "disable_custom_urls": true,
       "disable_guests": true,
+      "integrations_ui_url": "",
+      "integrations_rest_url": "",
+      "integrations_widgets_urls": [],
       "default_theme": "custom-Catppuccin Mocha (Blue)",
       "room_directory": {
         "servers": []


### PR DESCRIPTION
## Problem

Clicking **Add extensions** in any Matrix room fails with "cannot connect to the integration manager".

Element Web has no `integrations_*` keys configured, so it falls back to the public Scalar manager at `scalar.vector.im`. Scalar authenticates a user by calling the homeserver's federation OpenID endpoint — and this Synapse is internal-only with federation off (`federation_domain_whitelist: []` in `kubernetes/apps/tools/synapse/app/externalsecret.yaml`). Scalar can never reach it. The failure is structural, not transient.

## Fix

Set `integrations_ui_url` and `integrations_rest_url` to empty strings and `integrations_widgets_urls` to an empty list in the Element configmap. Element hides the button instead of offering an action that always fails.

## Nothing is lost

An integration manager is only a catalog UI. It is not required for:

- **Widgets** — `/addwidget <url>` works natively in any room
- **Bots** — invite the bot's MXID (this is how `matrix-media-relay` already works)
- **Bridges** — deployed server-side as Synapse appservices

## Alternative considered

`turt2live/matrix-dimension` is the only self-hostable integration manager and would work against the internal Synapse (it reaches the OpenID endpoint over the cluster network, no federation needed). Rejected: effectively unmaintained since ~2022, no current arm64 images, needs its own Postgres, and its bundled catalog points mostly at services not running here. Not worth adopting dead software for a menu that `/addwidget` replaces.

## Verification

Embedded `config.json` re-parsed as valid JSON after the edit.

https://claude.ai/code/session_01KLjARKFwYwCPAK9fkKuBng