### PR TITLE
feat(sabnzbd): migrate from NZBGet with local scratch and NFS safeguards

### DIFF
--- a/docs/sabnzbd-migration.md
+++ b/docs/sabnzbd-migration.md
@@ -1,0 +1,364 @@
+# NZBGet → SABnzbd Migration Plan
+
+Status: **planning / awaiting approval**. No cluster or arr changes made yet.
+Discovery: 2026-09-02, from NZBGet 26.0 on the Synology (`10.0.3.2:10007`) via its unauthenticated
+JSON-RPC API (`/jsonrpc/config`, `/listgroups`, `/history`) — no UI scraping required.
+Revision 2 (2026-09-02): incorporates decisions on servers, priorities, local scratch storage, and a
+split pre-stage/cutover phase.
+
+---
+
+## 1. Current state (verified, not assumed)
+
+### NZBGet (Synology, outside the cluster)
+
+| Item | Value |
+|---|---|
+| Version | 26.0 |
+| Root (`MainDir`) | `/downloads` → **`/volume1/media/downloads`** (same NFS export the cluster already mounts) |
+| Complete / Incomplete | `/downloads/complete`, `/downloads/incomplete` |
+| News servers | 12 (see §3) — 360 total connections configured |
+| Categories | `movies`, `movies-4k`, `tvshows`, `music`, `software`, `private` |
+| RSS feeds | none |
+| Post-processing | `nzbgeek-reporting.py` referenced in config but **the file does not exist** — dropped |
+| Queue at discovery | 0 items |
+| History | 150 items — 109 success, **41 `FAILURE/HEALTH` (27%)** |
+
+### Cluster side
+
+- `kubernetes/apps/media/sabnzbd/` **exists but is commented out** of `kubernetes/apps/media/kustomization.yaml`
+  (alongside `plex` and `qbittorrent`). SABnzbd has never run; there is no PVC and no state to preserve.
+- Existing HelmRelease already: app-template 5.0.1, image `ghcr.io/home-operations/sabnzbd:5.1.2`,
+  UID 1027 / GID 100 (matches NFS ownership), Longhorn 1Gi `/config`, NFS `/volume1/media` → `/data/media`,
+  internal route, ExternalSecret pulling `api_key` / `nzb_key` from the 1Password `sabnzbd` item.
+- Sonarr / Radarr / Radarr4k all point at **NZBGet `10.0.3.2:10007`** with categories
+  `tvshows` / `movies` / `movies-4k`, each with a remote path mapping keyed to host `10.0.3.2`.
+- Prowlarr: 16 indexers (11 usenet, 5 torrent), full-sync to all three arrs, one download client (`nzbget`).
+- Unpackerr points at `/data/media/downloads/complete/{sonarr,radarr,radarr4k}` — **these directories do not
+  exist**; the real ones are `movies`, `tvshows`, `movies-4k`. Unpackerr has been a no-op.
+
+### The single most important discovery
+
+NZBGet's `/downloads` **is** `/volume1/media/downloads` — the same export SABnzbd already mounts at
+`/data/media`. SABnzbd's `complete_dir` lands on byte-identical paths. So:
+
+- Hardlinks / atomic moves into `/data/media/{movies,tvshows,movies4k}` keep working. No copy penalty.
+- No data migration. Nothing to copy. The complete tree is reused in place.
+- The arrs' remote path mappings are keyed by **host** `10.0.3.2`; the SABnzbd client's host will be
+  `sabnzbd.media.svc.cluster.local`, so the mappings simply won't match it. They are inert rather than
+  dangerous — cleaned up at cutover rather than being a cutover-blocking edit.
+
+---
+
+## 2. Target architecture
+
+```
+Prowlarr ──sync──▶ Sonarr / Radarr / Radarr4k ──nzb──▶ SABnzbd (media ns, in-cluster)
+                                                            │
+              ┌─────────────────────────────────────────────┤
+              │ /config          Longhorn 1Gi   (SAB-owned, UI-writable, backed up)
+              │ /downloads/incomplete  Longhorn 250Gi on longhorn-scratch  ← NEW, local SSD
+              │ /data/media      NFS csi-driver-nfs PV, hard mount
+              │                    └── downloads/complete/<category>  →  library
+              └── watchdog sidecar + canary probes ──▶ halt on NFS loss
+```
+
+Deliberate departures from today:
+- **Incomplete work moves off NFS onto local Longhorn SSD.** Par2 verify/repair and unpack — the write-
+  amplifying phases — stay entirely local. Only the finished release crosses the NAS link, which is the
+  same bytes that would have been written anyway. See §5c for sizing.
+- SABnzbd unpacks natively with Direct Unpack on → **unpackerr becomes unnecessary** (retired in §8).
+- Aggressive early-failure detection turned on from day one (§5d) — this is the 27% problem.
+- NZBGet retired on the Synology after soak.
+
+---
+
+## 3. News servers — all 12 carried over, priorities preserved
+
+**Decision (confirmed): keep all 12, keep the priority ordering exactly as it is.** The ordering is
+intentional, not an accident: it is a *breadth-first* strategy. The ten smaller / bespoke / block accounts
+sit at tier 0 and are tried first, because between them they reach articles the big providers don't carry.
+The paid `Newshosting (Personal)` account sits at tier 3 as the reliable fallback, and `Tweak (free)` at
+tier 4 provides the 4300-day deep-retention backfill. This deliberately spares the primary account's
+capacity and maximises the chance of finding obscure content. NZBGet's `Level` maps 1:1 onto SABnzbd's
+server `priority` (lower = tried first), so this transfers exactly.
+
+| NZBGet # | Name | Host:Port | Conn | Priority | Optional | Retention |
+|---|---|---|---|---|---|---|
+| 3 | NewsDemon | news.newsdemon.com:**80** | 40 | 0 | yes | — |
+| 5 | Usenet.farm | news4.usenet.farm:563 | 40 | 0 | yes | — |
+| 7 | NewsGroupNinja | news.newsgroup.ninja:563 | 40 | 0 | yes | — |
+| 10 | NewsGroup Direct | nl.newsgroupdirect.com:563 | 40 | 0 | yes | — |
+| 4 | SuperNews | news.supernews.com:443 | 25 | 0 | yes | — |
+| 8 | TweakNews | news.tweaknews.eu:563 | 20 | 0 | yes | — |
+| 11 | Newshosting (2nd acct) | news.newshosting.com:443 | 20 | 0 | yes | — |
+| 2 | AstraWeb | ssl-us.astraweb.com:443 | 15 | 0 | yes | — |
+| 6 | UsenetServer-2 | news.usenetserver.com:443 | 10 | 0 | yes | — |
+| 9 | EasyNews | secure.news.easynews.com:8000 | 10 | 0 | yes | — |
+| 1 | **Newshosting (Personal)** | news.newshosting.com:443 | 60 | 3 | no | — |
+| 12 | Tweak (newshosting free) | newshosting.tweaknews.eu:563 | 40 | 4 | no | 4300d |
+
+**Correction from P1 testing:** `NewsDemon` is configured as port **80** with `Encryption=yes`, which
+looks contradictory — 80 is the plaintext NNTP port. It was flagged as a fix in revision 2. Live testing
+proved that wrong: NewsDemon genuinely serves **TLS on port 80** (plaintext on 80 times out, TLS on 80
+authenticates, and 563 also works). The config is correct as written and is migrated unchanged.
+
+### P1 connectivity test results (2026-09-02, TLS connect + `AUTHINFO` against each server)
+
+**5 of 12 authenticate. 7 fail.** This is almost certainly the mechanism behind the 27% `FAILURE/HEALTH`
+rate: seven of the ten tier-0 servers — the ones tried *first* — are dead, so every grab burns retries
+against them before reaching a working provider.
+
+| Server | Priority | Result |
+|---|---|---|
+| NewsDemon | 0 | ✅ OK (TLS on :80 confirmed) |
+| Usenet.farm | 0 | ✅ OK |
+| NewsGroupNinja | 0 | ✅ OK |
+| **Newshosting (Personal)** | 3 | ✅ OK |
+| **Tweak (newshosting free)** | 4 | ✅ OK |
+| NewsGroup Direct | 0 | ❌ `502 Connection failure. Please contact technical support.` |
+| SuperNews | 0 | ❌ `481 Invalid username or password` |
+| TweakNews | 0 | ❌ `502 Authentication Failed` |
+| Newshosting (2nd acct) | 0 | ❌ `502 Authentication Failed` |
+| AstraWeb | 0 | ❌ `502 Authentication Failed` |
+| UsenetServer-2 | 0 | ❌ `502 Authentication Failed` |
+| EasyNews | 0 | ❌ `502 Authentication Failed` |
+
+All 12 are migrated. The 7 failures ship with `enable = 0` and a note recording the exact error and test
+date, so nothing is lost and any account you renew is a one-flag change. **The breadth-first strategy is
+sound, but it is currently running on 3 working tier-0 servers, not 10** — worth knowing before judging
+whether breadth is delivering.
+
+---
+
+## 4. Setting-by-setting mapping
+
+| NZBGet | Value | SABnzbd equivalent | Target value |
+|---|---|---|---|
+| `MainDir` | `/downloads` | — | — |
+| `InterDir` | `/downloads/incomplete` (NFS) | `download_dir` | **`/downloads/incomplete` (local Longhorn)** |
+| `DestDir` | `/downloads/complete` | `complete_dir` | `/data/media/downloads/complete` (NFS, unchanged) |
+| `NzbDir` | `/downloads/nzb` | `dirscan_dir` | `/data/media/downloads/nzb` |
+| `QueueDir`/`TempDir` | `/downloads/{queue,tmp}` | internal `/config/admin` | SAB-managed, on Longhorn |
+| `ScriptDir` | `/config/scripts` | `script_dir` | `/config/scripts` (empty — no scripts carried over) |
+| `Unpack = yes` | | `enable_unrar`, `enable_7zip` | on |
+| `DirectUnpack = no` | | `direct_unpack` | **on** (upgrade) |
+| `UnpackCleanupDisk = yes` | | `cleanup_list`, `del_failed` | on |
+| `ParCheck = auto` | | `quick_check` | on — par only when quick-check fails |
+| `ParRepair = yes` | | `enable_par_repair` | on |
+| `ParScan = extended` | | `par2_multicore` | on |
+| `HealthCheck = delete` | | `fail_hopeless_jobs`, `abort_on_missing_files` | on — see §5d |
+| `DupeCheck = yes` | | `no_dupes` / `no_series_dupes` | on |
+| `ArticleCache = 200` MB | | `cache_limit` | `512M` (pod limit 2Gi) |
+| `DiskSpace = 250` MB | | `download_free` | **`40G`** on the scratch volume (§5c) |
+| — | | `complete_free` | `25G` on the NFS volume |
+| `KeepHistory = 30` d | | `history_retention` | 30 days |
+| `ExtCleanupDisk` | `.par2,.sfv,_brokenlog.txt` | `cleanup_list` | `par2,sfv,nfo,txt,srr` |
+| `UnpackIgnoreExt` | `.cbr` | — | leave `.cbr` untouched |
+| `DownloadRate = 0` | unlimited | `bandwidth_max` | unlimited |
+| `Extensions` | `nzbgeek-reporting.py` | — | **dropped** (file doesn't exist) |
+
+### Category mapping
+
+| Category | SAB dir | Consumer | NZBGet aliases → SAB "indexer categories" |
+|---|---|---|---|
+| `movies` | `movies` | Radarr | `movies*, 2000, 2030, 2040, 2050` |
+| `movies-4k` | `movies-4k` | Radarr4k | (none today) |
+| `tvshows` | `tvshows` | Sonarr | `tv*, TV*` |
+| `music` | `music` | manual | `audio*` |
+| `software` | `software` | manual | `pc*` |
+| `private` | `private` | manual | `xxx*, private*, 6000-6070` |
+
+---
+
+## 5. Design decisions
+
+### 5a. Storage safeguard — "halt if the NAS goes away" (both mechanisms, as requested)
+
+Three layers, defence in depth:
+
+1. **Dedicated NFS PV with explicit mount options.** The current `persistence.media.type: nfs` uses an
+   inline volume, which cannot set mount options. Replace with a `PersistentVolume`/`PVC` pair on the
+   existing `csi-driver-nfs` with `mountOptions: [hard, nfsvers=4.1, timeo=600, retrans=2, nconnect=8]`.
+   `hard` (not `soft`) is deliberate: `soft` returns IO errors mid-write and can corrupt a partially
+   written file. Under `hard`, an outage *blocks* IO — which is exactly what the probes detect.
+
+2. **Canary probes (the enforcement mechanism).** `startup`, `liveness` and `readiness` exec probes:
+   ```
+   test -f /data/media/.sabnzbd-canary && test -w /data/media/downloads/complete
+   ```
+   `timeoutSeconds: 10`, `periodSeconds: 30`, `failureThreshold: 2`. A hung `hard` mount makes the exec
+   time out → probe failure → liveness restarts the pod and readiness pulls it from the Service, so the
+   arrs stop queueing to it. With the NAS down the pod settles into CrashLoopBackOff — halted, as
+   requested — and self-heals when storage returns.
+
+3. **Watchdog sidecar (fast halt + explicit signal).** `shareProcessNamespace: true`; a busybox sidecar
+   stats the canary every 15s and on failure logs a structured line and `SIGTERM`s the SABnzbd process
+   immediately rather than waiting up to a full liveness cycle. Alloy already ships that log to Loki, and
+   a `PrometheusRule` beside the app alerts to Matrix on (a) readiness 0 for 2m, (b) restarts > 3/15m.
+
+Note the scratch volume changes the blast radius for the better: with incomplete work on local SSD, an NFS
+outage can no longer corrupt an in-progress unpack — it can only block the final move.
+
+### 5b. Config delivery — encrypted, declarative, *and* still editable in the UI
+
+**Seed-and-merge**, not overwrite:
+
+- The complete `sabnzbd.ini` lives as a single multi-line field (`config_seed`) on the existing 1Password
+  **`sabnzbd`** item (confirmed OK to add), surfaced by the existing ExternalSecret. Nothing readable in
+  git; encrypted at rest in 1Password; no SOPS exception needed (matches repo standard §5).
+- An **init container** (reusing the SABnzbd image — python3 already present) runs every start:
+  - `/config/sabnzbd.ini` **missing** → write the seed verbatim. First boot / PVC loss = full recovery.
+  - `/config/sabnzbd.ini` **present** → merge only an explicitly declared *managed key set*
+    (`[servers]`, `[categories]`, `api_key`, `nzb_key`, `download_dir`, `complete_dir`, `host_whitelist`)
+    and leave every other key exactly as SABnzbd wrote it.
+- **So UI edits persist.** Anything outside the managed set is never touched. Anything inside it is
+  1Password-authoritative by design — you don't want a hand-edited news server drifting silently.
+- **Round-trip:** `./scripts/sabnzbd-export-config.sh` dumps the running ini, strips volatile runtime keys, and
+  writes it back to the 1Password field so the seed stays current.
+- **Backup regardless:** a daily CronJob copies `sabnzbd.ini` + `/config/admin` to
+  `/data/media/.backups/sabnzbd/`, 14-day retention, on top of the Longhorn recurring backup of the PVC.
+
+### 5c. Local scratch sizing — how big does the incomplete volume need to be?
+
+Measured from the last 150 completed jobs (924 GB total):
+
+| Category | n | mean | median | p90 | p99 | max |
+|---|---|---|---|---|---|---|
+| movies | 30 | 21.0 G | 21.6 G | 37.7 G | 39.1 G | **39.1 G** |
+| tvshows | 120 | 2.5 G | 2.9 G | 3.9 G | 6.4 G | 6.5 G |
+| all | 150 | 6.2 G | 3.0 G | 24.1 G | 38.3 G | 39.1 G |
+
+Your instinct was right — the tail is entirely 1080p BluRay remuxes at 32–39 GB. Sizing:
+
+- **One worst-case job, RAR'd:** 39 G archive + 39 G extracted concurrently = **~80 G**
+- **Post-processing overlap:** SAB post-processes job N while downloading job N+1 → **+40 G**
+- **Queue burst headroom:** a couple more large movies or a full season pack queued → **+80 G**
+- **`download_free` guard:** SAB pauses rather than filling the volume → **+40 G**
+
+**Recommendation: a 250Gi PVC.** That is ~3× the single-job worst case and covers a realistic burst of
+4–5 remuxes in flight, with SAB pausing (not failing) if it somehow gets deeper than that.
+
+**On a new `longhorn-scratch` StorageClass — `numberOfReplicas: "1"`, backups excluded.** This matters:
+
+- Both existing classes are `numberOfReplicas: 2`, which would make a 250Gi volume consume **500 GB** of
+  cluster storage. Current Longhorn free-to-schedule capacity is 472 / 434 / 348 GB across the three
+  nodes (824 GB each, 100% over-provisioning cap), so 500 GB would eat more than half the remaining
+  headroom on two nodes.
+- Replicating *scratch* data is pure waste — it doubles SSD write amplification on exactly the workload
+  that churns hardest, to protect data that is definitionally re-downloadable.
+- At replicas 1, the 250Gi lands on one node with room to spare. If that node dies, in-flight downloads
+  are lost and SAB/the arrs re-grab. That is the correct trade for temp data.
+- Backups excluded (`recurringJobSelector: exclude`) — backing up 250 GB of churning temp files to the
+  NFS backup target would be actively harmful.
+
+Net effect: 250 GB of cluster storage consumed, all par2 repair and unpack IO moved off the NAS link.
+
+**Measured, not assumed** (2026-09-02, 1 GiB `dd` with `O_DIRECT` from pods in `media`):
+
+| | write | read | rename |
+|---|---|---|---|
+| NFS (`/data/media`) | 105 MB/s | 112 MB/s | 5 ms |
+| Longhorn (default class, 2 replicas) | 109 MB/s | 230 MB/s | — |
+
+The NAS link is ~1GbE and already saturated; that is the binding constraint on the whole pipeline. Honest
+accounting of what the move buys:
+
+- **Per 39 GB RAR'd job**, bytes crossing the node NIC drop from **117 GB** (download write + unpack read +
+  extracted write, all to NFS) to **39 GB** (only the final copy). History is 65 `SUCCESS/UNPACK` vs 44
+  `SUCCESS/PAR`, so ~60% of jobs are RAR'd — blended, roughly a **55% cut in NAS traffic**, not 3×.
+- **The regression:** the move to `complete` stops being a free 5 ms same-filesystem rename and becomes a
+  real copy — **~6 min per 39 GB remux**, ~25 s per TV episode. For the ~40% of jobs that arrive unRAR'd,
+  local scratch is a net loss on wall-clock.
+- **The two arguments that actually carry it** are contention and latency, not throughput. Download bytes
+  and NFS-write bytes share one 1GbE NIC, so writing incomplete to NFS caps effective download speed near
+  half the link — and Direct Unpack makes that worse. Local scratch gives the download the whole link and
+  stops unpack churn from stepping on Plex streams. Separately, par2 **repair** is random-access and
+  latency-bound, where NFS is far worse than the friendly sequential `dd` gap above suggests.
+- The 109 MB/s Longhorn write is on the **2-replica** default class and is network-bound by synchronous
+  replication. `longhorn-scratch` at `numberOfReplicas: 1` writes to local disk only, so real scratch
+  throughput should be well above that. **This is an inference, not a measurement** — verify directly in P3.
+
+Decision (2026-09-02): proceed with local scratch; local storage expansion is planned independently.
+
+### 5d. Early failure detection — turning on the 27% fix
+
+41 of 150 history items are `FAILURE/HEALTH`. Promoted from "suggestion" into the migration itself:
+
+| SABnzbd setting | Target | What it kills |
+|---|---|---|
+| `fail_hopeless_jobs` | on | jobs whose remaining articles can't reach the completion threshold — aborted immediately instead of downloading to a guaranteed par failure |
+| `abort_on_missing_files` | on | jobs missing files outright at queue time |
+| `req_completion_rate` | `100.2` | the health floor below which a job is declared dead |
+| `unwanted_extensions` | `exe,com,bat,scr,vbs,lnk,pif` | malware-bait releases |
+| `action_on_unwanted_extensions` | `2` (fail job) | ...and fails them rather than just warning |
+| `pause_on_pwrar` | `2` (abort) | password-protected RARs — a common cause of a "successful" download that can never be unpacked |
+| `enable_all_par` | off | don't pull par2 blocks you don't need |
+| `propagation_delay` | `15` min | don't grab an NZB before the articles have finished propagating — a meaningful share of health failures |
+
+The payoff is a job that would have failed anyway fails in seconds instead of after 39 GB, and the arrs
+get the failure signal fast enough to try the next release while the search is still fresh.
+
+---
+
+## 6. Gaps
+
+| # | Gap | Impact | Resolution |
+|---|---|---|---|
+| 1 | Unpackerr paths point at non-existent dirs | Silent no-op today | Retire unpackerr for usenet (SAB unpacks natively) — §8 |
+| 2 | Prowlarr download client is `nzbget` | Prowlarr manual grabs break at cutover | SAB added disabled in P4, enabled in P5 |
+| 3 | Stale remote path mappings on all 3 arrs | **Inert** — keyed to host `10.0.3.2`, won't match SAB | Delete during P5 cleanup |
+| 4 | Some of the 12 servers may have expired credentials | Wasted connections, auth noise | Connectivity test in P1; failures ship disabled with a report |
+| 5 | `NewsDemon` port 80 + `Encryption=yes` | Broken or downgraded TLS | Correct to 563 during seed generation |
+| 6 | SAB runs UID 1027/GID 100, repo default is 65534 | `task validate:security-ctx` warning | Intentional (NFS ownership is 1027:users) — document the exception |
+| 7 | `sabnzbd` ks is commented out of `apps/media/kustomization.yaml` | — | One-line uncomment in P2 |
+| 8 | Arr/Prowlarr config is DB state, not GitOps | P4/P5 changes can't be expressed in Flux | Applied via idempotent scripts committed to `scripts/`, so they're reviewable and repeatable |
+
+---
+
+## 7. Phased plan
+
+Branch: `1activegeek/nzbget-sabnzbd-conversion`. Never commit to main (Flux deploys instantly).
+
+| Phase | Work | Gate |
+|---|---|---|
+| **P0** ✅ | Discovery — NZBGet config, arr/Prowlarr state, NFS layout, size distribution | done |
+| **P1** ✅ | Connectivity-tested all 12 servers (5 pass / 7 fail); generated the `sabnzbd.ini` seed — priorities preserved, 7 dead servers disabled with notes, failure-detection baked in — validated every key against SABnzbd 5.1.2 source; pushed to 1Password `sabnzbd.config_seed` (6262 bytes) | done |
+| **P2** ✅ | Manifests: `longhorn-scratch` SC, 250Gi scratch PVC, NFS PV/PVC with mount options, canary probes, watchdog sidecar, seed-merge init container, config-backup CronJob, PrometheusRule, uncomment ks. validated | **PR open — your approval** |
+| **P3** | Deploy. Verify: pod healthy, per-server connection report, one manual test NZB → download → unpack → lands in `complete/<cat>`. Pull the NFS mount and confirm the pod halts and recovers. | verification report |
+| **P4** | **Pre-stage, everything disabled.** Add SABnzbd as a download client to Sonarr, Radarr, Radarr4k and Prowlarr with `enable: false`, correct categories, and run each client's built-in **Test** to prove connectivity and auth. NZBGet stays enabled and untouched. Nothing changes behaviourally. | pre-flight report for you to validate |
+| **P5** | 🔒 **CUTOVER — gated on your explicit go.** Flip `enable: true` on the four SAB clients, `enable: false` on the four NZBGet clients. Delete the stale remote path mappings. Retire unpackerr. | your word |
+| **P6** | Soak 7 days, then retire NZBGet on the Synology and reclaim `/downloads/{queue,tmp,nzb,incomplete}` | — |
+
+**P1–P4 are entirely non-disruptive.** NZBGet keeps running and keeps serving the arrs throughout. At the
+end of P4 everything is wired, tested and sitting inert — the cutover in P5 is four enable-flag flips, and
+rollback is flipping them back. Each phase's script is idempotent and committed, so P5 is a single command
+whenever you're ready.
+
+---
+
+## 8. Suggested upgrades (post-merge follow-ons)
+
+Ranked by value. Items 1–2 from revision 1 have been **promoted into the migration itself** (Direct Unpack
+in §4, failure detection in §5d), and local scratch storage is now in scope (§5c).
+
+1. **Retire unpackerr** *(agreed)*. Its only job was NZBGet's post-unpack gap, its paths are wrong, and SAB
+   unpacks natively with Direct Unpack on. One fewer deployment, one fewer NFS mount.
+2. **Metrics + dashboard.** `sabnzbd_exporter` → ServiceMonitor → Grafana dashboard ConfigMap, with alerts
+   for queue stalled, zero servers connected, scratch volume filling, and `download_free` low.
+3. **Matrix notifications** for failed jobs via the existing hookshot webhook (`docs/matrix-webhooks.md`) —
+   pairs naturally with the §5d failure detection so you see *what* is failing, not just that it failed.
+4. **Uptime Kuma monitor** on `sabnzbd.${SECRET_DOMAIN}` per the monitoring standard.
+5. **Server health scoring.** Once metrics exist, per-server article-miss rates will show which of the ten
+   tier-0 accounts are actually earning their place in the breadth-first strategy and which are just adding
+   latency before the fallback. Data-driven, rather than pruning on assumption.
+6. **Re-evaluate `nconnect`** after a week of real traffic — with unpack IO off the NAS the link profile
+   changes, and the optimum may differ from the initial 8.
+7. **Revisit `plex` and `qbittorrent`**, both also commented out of `apps/media/kustomization.yaml` —
+   out of scope here, but worth a decision.
+
+---
+
+## 9. Open items
+
+None blocking. P1 through P4 can run unattended once the P2 PR is approved; P5 waits on your explicit go.

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -22,5 +22,5 @@ resources:
   - ./grimmory/ks.yaml
   - ./audiobookshelf/ks.yaml
   # - ./plex/ks.yaml ## Disabling temporarily
-  # - ./sabnzbd/ks.yaml ## Disabling temporarily
+  - ./sabnzbd/ks.yaml
   # - ./qbittorrent/ks.yaml ## Disabling temporarily

--- a/kubernetes/apps/media/sabnzbd/app/configmap.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/configmap.yaml
@@ -1,0 +1,169 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sabnzbd-scripts
+data:
+  # ---------------------------------------------------------------------------
+  # seed-merge.py - runs as an init container on every pod start.
+  #
+  # First boot (or PVC loss): writes the seed from 1Password verbatim, so the
+  # whole configuration is recoverable from the vault alone.
+  #
+  # Every boot after that: replaces ONLY the managed sections/keys and leaves
+  # everything SABnzbd wrote for itself untouched, so changes made in the web UI
+  # persist. Managed state (news servers, categories, folders) is
+  # 1Password-authoritative by design - a hand-edited news server should not
+  # drift silently away from source.
+  #
+  # Round-trip a deliberate UI change back into source with:
+  #   ./scripts/sabnzbd-export-config.sh
+  # ---------------------------------------------------------------------------
+  seed-merge.py: |
+    #!/usr/bin/env python3
+    import os, shutil, sys, time
+
+    SEED = "/seed/sabnzbd.ini.seed"
+    INI = "/config/sabnzbd.ini"
+
+    MANAGED_SECTIONS = {"servers", "categories"}
+    MANAGED_MISC = {
+        "download_dir", "complete_dir", "dirscan_dir", "script_dir",
+        "nzb_backup_dir", "permissions", "download_free", "complete_free",
+        "fulldisk_autoresume", "direct_unpack", "enable_unrar", "enable_7zip",
+        "enable_filejoin", "enable_tsjoin", "enable_par_cleanup",
+        "enable_all_par", "flat_unpack", "ignore_samples",
+        "deobfuscate_final_filenames", "cleanup_list", "fail_hopeless_jobs",
+        "fast_fail", "req_completion_rate", "propagation_delay",
+        "pause_on_pwrar", "unwanted_extensions",
+        "action_on_unwanted_extensions", "unwanted_extensions_mode",
+        "no_dupes", "no_smart_dupes", "dupes_propercheck", "cache_limit",
+        "bandwidth_max", "bandwidth_perc", "history_retention_option",
+        "history_retention_number",
+    }
+
+    def parse(text):
+        """SABnzbd uses configobj: [section] with optional [[subsection]]."""
+        out, sec, sub = [], None, None
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line.startswith("[[") and line.endswith("]]"):
+                sub = line[2:-2]
+                out.append(("sub", sec, sub, None, None, raw))
+            elif line.startswith("[") and line.endswith("]"):
+                sec, sub = line[1:-1], None
+                out.append(("sec", sec, None, None, None, raw))
+            elif "=" in line and not line.startswith("#"):
+                k, v = line.split("=", 1)
+                out.append(("kv", sec, sub, k.strip(), v.strip(), raw))
+            else:
+                out.append(("raw", sec, sub, None, None, raw))
+        return out
+
+    def section_block(rows, name):
+        """Return the verbatim lines belonging to top-level section `name`."""
+        block, inside = [], False
+        for kind, sec, sub, k, v, raw in rows:
+            if kind == "sec":
+                inside = sec == name
+                if inside:
+                    continue
+            if inside:
+                block.append(raw)
+        while block and not block[-1].strip():
+            block.pop()
+        return block
+
+    def main():
+        if not os.path.exists(SEED):
+            sys.exit("seed not present at %s - is the ExternalSecret synced?" % SEED)
+        seed_text = open(SEED).read()
+
+        if not os.path.exists(INI):
+            os.makedirs(os.path.dirname(INI), exist_ok=True)
+            open(INI, "w").write(seed_text)
+            print("no existing sabnzbd.ini - wrote seed verbatim (%d bytes)" % len(seed_text))
+            return
+
+        shutil.copy2(INI, INI + ".bak-" + time.strftime("%Y%m%d-%H%M%S"))
+        cfgdir = os.path.dirname(INI)
+        baks = sorted(f for f in os.listdir(cfgdir) if f.startswith("sabnzbd.ini.bak-"))
+        for stale in baks[:-5]:
+            os.remove(os.path.join(cfgdir, stale))
+        cur, seed = parse(open(INI).read()), parse(seed_text)
+        seed_misc = {k: v for kind, sec, sub, k, v, _ in seed
+                     if kind == "kv" and sec == "misc" and sub is None}
+
+        out, changed, inside_managed = [], [], False
+        for kind, sec, sub, k, v, raw in cur:
+            if kind == "sec":
+                inside_managed = sec in MANAGED_SECTIONS
+                out.append(raw)
+                if inside_managed:
+                    out.extend(section_block(seed, sec))
+                    changed.append("[%s] replaced from seed" % sec)
+                continue
+            if inside_managed:
+                continue
+            if kind == "kv" and sec == "misc" and sub is None and k in MANAGED_MISC:
+                want = seed_misc.get(k)
+                if want is not None and want != v:
+                    changed.append("misc.%s: %r -> %r" % (k, v, want))
+                    out.append("%s = %s" % (k, want))
+                    continue
+            out.append(raw)
+
+        present = {k for kind, sec, sub, k, v, _ in cur
+                   if kind == "kv" and sec == "misc" and sub is None}
+        missing = [(k, v) for k, v in seed_misc.items()
+                   if k in MANAGED_MISC and k not in present]
+        if missing:
+            for i, line in enumerate(out):
+                if line.strip() == "[misc]":
+                    for k, v in missing:
+                        out.insert(i + 1, "%s = %s" % (k, v))
+                        changed.append("misc.%s added = %r" % (k, v))
+                    break
+
+        for sec in MANAGED_SECTIONS:
+            if not any(kind == "sec" and s == sec for kind, s, _, _, _, _ in cur):
+                out.append("[%s]" % sec)
+                out.extend(section_block(seed, sec))
+                changed.append("[%s] created from seed" % sec)
+
+        open(INI, "w").write("\n".join(out) + "\n")
+        print("merged seed into existing sabnzbd.ini; %d change(s)" % len(changed))
+        for c in changed:
+            print("  " + c)
+
+    main()
+
+  # ---------------------------------------------------------------------------
+  # watchdog.sh - sidecar. Halts SABnzbd the moment the NAS mount goes away,
+  # rather than waiting out a full liveness cycle. Runs in a shared PID
+  # namespace so it can signal the app container's process directly.
+  # ---------------------------------------------------------------------------
+  watchdog.sh: |
+    #!/bin/sh
+    CANARY=/data/media/.sabnzbd-canary
+    INTERVAL=15
+    FAILURES=0
+    THRESHOLD=2
+    echo "[watchdog] armed: checking $CANARY every ${INTERVAL}s, halt after $THRESHOLD consecutive failures"
+    while true; do
+      if timeout 10 test -e "$CANARY" 2>/dev/null; then
+        if [ "$FAILURES" -ne 0 ]; then
+          echo "[watchdog] storage recovered after $FAILURES failed check(s)"
+        fi
+        FAILURES=0
+      else
+        FAILURES=$((FAILURES + 1))
+        echo "[watchdog] STORAGE CHECK FAILED ($FAILURES/$THRESHOLD): $CANARY unreachable - NFS mount is down or hung"
+        if [ "$FAILURES" -ge "$THRESHOLD" ]; then
+          echo "[watchdog] HALTING SABnzbd: remote storage is unavailable, continuing would risk partial writes"
+          pkill -TERM -f 'SABnzbd.py' || pkill -TERM -f sabnzbd || echo "[watchdog] no SABnzbd process matched"
+          sleep 30
+        fi
+      fi
+      sleep "$INTERVAL"
+    done

--- a/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/externalsecret.yaml
@@ -14,6 +14,10 @@ spec:
       data:
         SABNZBD__API_KEY: "{{ .api_key }}"
         SABNZBD__NZB_KEY: "{{ .nzb_key }}"
+        # Full sabnzbd.ini, generated from the NZBGet migration and held encrypted
+        # in 1Password. Consumed by the seed-merge init container; see
+        # docs/sabnzbd-migration.md §5b. Contains all 12 news server credentials.
+        sabnzbd.ini.seed: "{{ .config_seed }}"
   dataFrom:
     - extract:
         key: sabnzbd

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -14,6 +14,32 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         strategy: Recreate
+        initContainers:
+          # Materialise/merge sabnzbd.ini from the 1Password seed. Also plants the
+          # canary the probes and watchdog key off - if the NFS mount is missing at
+          # start, this fails and the pod never runs, which is the intended halt.
+          seed-config:
+            image:
+              repository: ghcr.io/home-operations/sabnzbd
+              tag: 5.1.2
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -e
+                touch /data/media/.sabnzbd-canary
+                mkdir -p /downloads/incomplete /data/media/downloads/complete
+                python3 /scripts/seed-merge.py
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
         containers:
           app:
             image:
@@ -32,18 +58,37 @@ spec:
               - secretRef:
                   name: sabnzbd-secret
             probes:
+              # Liveness and readiness both assert the NAS mount is reachable AND
+              # the API answers. A hung `hard` NFS mount makes the stat block, the
+              # exec times out, and the pod is restarted / pulled from the Service
+              # so the *arrs stop queueing to it.
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /api?mode=version
-                    port: &port 8080
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
+                  exec:
+                    command:
+                      - python3
+                      - -c
+                      - |
+                        import os, urllib.request
+                        os.stat("/data/media/.sabnzbd-canary")
+                        urllib.request.urlopen("http://localhost:8080/api?mode=version", timeout=5)
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 2
               readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  exec:
+                    command: ["/bin/sh", "-c", "test -e /data/media/.sabnzbd-canary"]
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                  failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
@@ -51,11 +96,72 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 memory: 2Gi
+          # Daily copy of the SABnzbd config to the NAS, independent of the
+          # Longhorn backup of the PVC - two restore paths. Runs as a sidecar
+          # rather than a CronJob because /config is RWO Longhorn and is already
+          # attached to this pod.
+          config-backup:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0
+            command:
+              - /bin/sh
+              - -c
+              - |
+                DEST=/data/media/.backups/sabnzbd
+                while true; do
+                  if mkdir -p "$DEST" 2>/dev/null; then
+                    TS=$(date +%Y%m%d-%H%M%S)
+                    if tar czf "$DEST/sabnzbd-config-$TS.tar.gz" -C /config sabnzbd.ini admin 2>/dev/null; then
+                      echo "[config-backup] wrote $DEST/sabnzbd-config-$TS.tar.gz"
+                      find "$DEST" -name 'sabnzbd-config-*.tar.gz' -type f -mtime +14 -print -delete
+                    else
+                      echo "[config-backup] tar failed - skipping this cycle"
+                    fi
+                  else
+                    echo "[config-backup] destination unreachable - skipping this cycle"
+                  fi
+                  sleep 86400
+                done
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+          # Halts SABnzbd within ~30s of the NAS going away, rather than waiting
+          # out a liveness cycle. Shares the pod PID namespace so it can signal
+          # the app process directly. See docs/sabnzbd-migration.md §5a.
+          watchdog:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0
+            command: ["/bin/sh", "/scripts/watchdog.sh"]
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
     defaultPodOptions:
+      # Required for the watchdog to signal the SABnzbd process.
+      shareProcessNamespace: true
+      terminationGracePeriodSeconds: 30
       securityContext:
         runAsNonRoot: true
+        # 1027:100 matches ownership on the Synology export; deliberately not the
+        # repo-default 65534 (task validate:security-ctx will flag this).
         runAsUser: 1027
         runAsGroup: 100
         fsGroup: 100
@@ -64,22 +170,65 @@ spec:
         controller: sabnzbd
         ports:
           http:
-            port: *port
+            port: 8080
     persistence:
       config:
         type: persistentVolumeClaim
         storageClass: longhorn
         accessMode: ReadWriteOnce
         size: 1Gi
-        globalMounts:
-          - path: /config
-      # NFS media mount - single root for hardlink support
+        advancedMounts:
+          sabnzbd:
+            seed-config:
+              - path: /config
+            app:
+              - path: /config
+            config-backup:
+              - path: /config
+      # Incomplete/working set on local SSD, off the NAS link. Sized at ~3x the
+      # largest observed job (39GB remux); see docs/sabnzbd-migration.md §5c.
+      scratch:
+        type: persistentVolumeClaim
+        storageClass: longhorn-scratch
+        accessMode: ReadWriteOnce
+        size: 250Gi
+        advancedMounts:
+          sabnzbd:
+            seed-config:
+              - path: /downloads
+            app:
+              - path: /downloads
+      # Static PVC (not the inline `type: nfs`) so the mount carries hard/nconnect
+      # options - see pvc.yaml.
       media:
-        type: nfs
-        server: ${NFS_SERVER}
-        path: /volume1/media #remediate
-        globalMounts:
-          - path: /data/media
+        existingClaim: sabnzbd-media
+        advancedMounts:
+          sabnzbd:
+            seed-config:
+              - path: /data/media
+            app:
+              - path: /data/media
+            watchdog:
+              - path: /data/media
+            config-backup:
+              - path: /data/media
+      seed:
+        type: secret
+        name: sabnzbd-secret
+        advancedMounts:
+          sabnzbd:
+            seed-config:
+              - path: /seed
+      scripts:
+        type: configMap
+        name: sabnzbd-scripts
+        defaultMode: 0555
+        advancedMounts:
+          sabnzbd:
+            seed-config:
+              - path: /scripts
+            watchdog:
+              - path: /scripts
     route:
       app:
         hostnames: ["{{ .Release.Name }}.${SECRET_DOMAIN}"]

--- a/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/kustomization.yaml
@@ -2,6 +2,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./storageclass.yaml
+  - ./pvc.yaml
+  - ./configmap.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./externalsecret.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/media/sabnzbd/app/prometheusrule.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/prometheusrule.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sabnzbd
+spec:
+  groups:
+    - name: sabnzbd.rules
+      rules:
+        - alert: SabnzbdNotReady
+          expr: |
+            kube_pod_container_status_ready{namespace="media", pod=~"sabnzbd-.*", container="app"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: SABnzbd is not ready
+            description: >-
+              SABnzbd has failed its readiness probe for 5m. The probe asserts both
+              that the NAS mount is reachable and that the API answers, so the most
+              likely cause is the Synology NFS export being down or hung. Downloads
+              are halted and the *arrs are no longer queueing to it.
+
+        - alert: SabnzbdRestarting
+          expr: |
+            increase(kube_pod_container_status_restarts_total{namespace="media", pod=~"sabnzbd-.*"}[15m]) > 3
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: SABnzbd is restarting repeatedly
+            description: >-
+              More than 3 container restarts in 15m. If this coincides with
+              SabnzbdNotReady, the storage watchdog is halting the process because
+              remote storage keeps disappearing.
+
+        - alert: SabnzbdScratchVolumeFilling
+          expr: |
+            kubelet_volume_stats_available_bytes{namespace="media", persistentvolumeclaim=~"sabnzbd-scratch"}
+              / kubelet_volume_stats_capacity_bytes{namespace="media", persistentvolumeclaim=~"sabnzbd-scratch"} < 0.15
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: SABnzbd scratch volume is filling up
+            description: >-
+              Less than 15% free on the incomplete/working volume. SABnzbd's own
+              download_free guard (40G) should pause the queue before it fills, but
+              a stuck post-processing job can hold space. Check for stalled unpacks.

--- a/kubernetes/apps/media/sabnzbd/app/pvc.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/pvc.yaml
@@ -1,0 +1,42 @@
+---
+# Static NFS PV for the media share.
+#
+# The app-template `persistence.type: nfs` shortcut builds an inline NFS volume,
+# which cannot carry mountOptions. SABnzbd needs them: `hard` so an outage blocks
+# rather than returning IO errors mid-write (a `soft` mount can corrupt an
+# in-flight unpack), and nconnect for throughput on a single 1GbE NAS link.
+# The blocking behaviour is what the canary probes and watchdog detect.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: sabnzbd-media
+spec:
+  capacity:
+    storage: 1Ti # not enforced for NFS; required by the API
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  mountOptions:
+    - nfsvers=4.1
+    - hard
+    - noatime
+    - nconnect=8
+    - timeo=600
+    - retrans=2
+  nfs:
+    server: ${NFS_SERVER}
+    path: /volume1/media
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sabnzbd-media
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: sabnzbd-media
+  resources:
+    requests:
+      storage: 1Ti

--- a/kubernetes/apps/media/sabnzbd/app/storageclass.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/storageclass.yaml
@@ -1,0 +1,30 @@
+---
+# Scratch storage for SABnzbd's incomplete/working directory.
+#
+# Single replica, no backups, on purpose:
+#  - The data is definitionally re-downloadable. Replicating it would double SSD
+#    write amplification on the hardest-churning workload in the cluster to
+#    protect bytes we can simply fetch again.
+#  - At numberOfReplicas: 2 a 250Gi volume consumes 500GB of cluster storage;
+#    free-to-schedule headroom at creation time was 472/434/348 GB per node.
+#  - recurringJobSelector points at the group "exclude", for which no RecurringJob
+#    exists (same trick as longhorn-nobackup) — backing up 250GB of churning
+#    temp files to the NAS would be actively harmful.
+#
+# Failure mode accepted: if the node holding the replica dies, in-flight
+# downloads are lost and SABnzbd/the *arrs re-grab them.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-scratch
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "30"
+  dataLocality: "best-effort"
+  fromBackup: ""
+  fsType: "ext4"
+  recurringJobSelector: '[{"name":"exclude","isGroup":true}]'

--- a/scripts/sabnzbd-export-config.sh
+++ b/scripts/sabnzbd-export-config.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Round-trip the running SABnzbd configuration back into 1Password.
+#
+# The seed-merge init container treats a declared set of keys (news servers,
+# categories, folders, the tuning in docs/sabnzbd-migration.md §4/§5d) as
+# 1Password-authoritative. Everything else you change in the web UI persists on
+# the PVC untouched. When you deliberately change one of the MANAGED keys in the
+# UI and want it to stick across a PVC rebuild, run this to make the vault match.
+#
+# Volatile runtime state is stripped so the seed stays a configuration document
+# rather than a snapshot of counters.
+#
+#   ./scripts/sabnzbd-export-config.sh --diff   # show what would change
+#   ./scripts/sabnzbd-export-config.sh          # write it back to 1Password
+#
+# Requires: an active op-session and a working KUBECONFIG.
+set -euo pipefail
+
+MODE="${1:-write}"
+NS=media
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+POD=$(kubectl get pod -n "$NS" -l app.kubernetes.io/name=sabnzbd -o jsonpath='{.items[0].metadata.name}')
+[[ -n "$POD" ]] || { echo "no sabnzbd pod found in $NS" >&2; exit 1; }
+
+kubectl exec -n "$NS" "$POD" -c app -- cat /config/sabnzbd.ini > "$WORK/live.ini"
+
+# Drop keys SABnzbd rewrites constantly; they are state, not configuration.
+python3 - "$WORK/live.ini" "$WORK/clean.ini" <<'PY'
+import sys
+VOLATILE = {
+    "__version__", "check_new_rel", "last_opendir", "queue_complete",
+    "notified_new_skin", "direct_unpack_tested", "config_conversion_version",
+    "sorters_converted", "fixed_ports", "usage_at_start", "expire_date",
+}
+src, dst = sys.argv[1], sys.argv[2]
+out = []
+for line in open(src).read().splitlines():
+    key = line.split("=")[0].strip() if "=" in line else ""
+    if key in VOLATILE:
+        continue
+    out.append(line.rstrip())
+while out and not out[-1]:
+    out.pop()
+open(dst, "w").write("\n".join(out) + "\n")
+print(f"exported {len(out)} lines", file=sys.stderr)
+PY
+
+op item get sabnzbd --vault homeops --format json > "$WORK/item.json"
+python3 - "$WORK/item.json" "$WORK/clean.ini" "$WORK/item.new.json" "$MODE" <<'PY'
+import json, sys, difflib
+item_path, ini_path, out_path, mode = sys.argv[1:5]
+item = json.load(open(item_path))
+new = open(ini_path).read()
+cur = next((f.get("value") or "" for f in item.get("fields", [])
+            if f.get("label") == "config_seed"), "")
+
+if cur == new:
+    print("config_seed already matches the running config - nothing to do")
+    sys.exit(3)
+
+diff = list(difflib.unified_diff(cur.splitlines(), new.splitlines(),
+                                 "1password", "running", lineterm="", n=1))
+# Never print the diff bodies: server credentials live in these lines.
+adds = sum(1 for d in diff if d.startswith("+") and not d.startswith("+++"))
+dels = sum(1 for d in diff if d.startswith("-") and not d.startswith("---"))
+secs = sorted({d.lstrip("+- ").split("=")[0].strip()
+               for d in diff
+               if d[:1] in "+-" and not d.startswith(("+++", "---")) and "=" in d})
+print(f"config_seed would change: +{adds} / -{dels} line(s)")
+print("keys touched: " + (", ".join(secs[:25]) or "(section structure only)"))
+
+if mode == "--diff":
+    sys.exit(3)
+
+item["fields"] = [f for f in item.get("fields", []) if f.get("label") != "config_seed"]
+item["fields"].append({"id": "config_seed", "label": "config_seed",
+                       "type": "CONCEALED", "value": new})
+json.dump(item, open(out_path, "w"))
+PY
+rc=$?
+[[ $rc -eq 3 ]] && exit 0
+[[ $rc -ne 0 ]] && exit $rc
+
+op item edit sabnzbd --vault homeops --template "$WORK/item.new.json" >/dev/null
+echo "config_seed updated in 1Password"

--- a/scripts/sabnzbd-prestage-arrs.sh
+++ b/scripts/sabnzbd-prestage-arrs.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Pre-stage SABnzbd as a DISABLED download client in Sonarr, Radarr, Radarr4k and
+# Prowlarr, then run each client's built-in connectivity test.
+#
+# This is migration phase P4 (see docs/sabnzbd-migration.md). It changes nothing
+# behaviourally: NZBGet stays enabled and keeps serving every grab. The point is to
+# have SABnzbd wired, category-correct and proven reachable, so that the P5 cutover
+# is nothing but flipping enable flags.
+#
+# *arr configuration lives in each app's SQLite DB, not in Git, so this is applied
+# over the API. It is idempotent — re-running updates the existing client rather
+# than creating a duplicate.
+#
+# The client body is built from each app's own /downloadclient/schema rather than
+# from hardcoded field names, because Sonarr, Radarr and Prowlarr each define a
+# different field set for the same SABnzbd implementation.
+#
+#   ./scripts/sabnzbd-prestage-arrs.sh --dry-run   # show what would change
+#   ./scripts/sabnzbd-prestage-arrs.sh             # stage (disabled) + test
+#
+# Requires: an active op-session (for the SABnzbd API key) and a working KUBECONFIG.
+set -euo pipefail
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+NS=media
+SAB_HOST=sabnzbd.media.svc.cluster.local
+SAB_PORT=8080
+
+# app : service-port : api-version : category
+TARGETS=(
+  "sonarr:8989:v3:tvshows"
+  "radarr:7878:v3:movies"
+  "radarr4k:7878:v3:movies-4k"
+  "prowlarr:9696:v1:"
+)
+
+log() { printf '%s\n' "$*" >&2; }
+
+SAB_API_KEY=$(op-session exec op read "op://homeops/sabnzbd/api_key")
+
+pf_pid=""
+cleanup() { [[ -n "${pf_pid}" ]] && kill "${pf_pid}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+prestage() {
+  local app=$1 port=$2 apiver=$3 cat=$4
+  local lport=$((port + 20000))
+  local rc=0
+
+  kubectl port-forward -n "$NS" "svc/$app" "$lport:$port" >/dev/null 2>&1 &
+  pf_pid=$!
+  sleep 3
+
+  local key base
+  key=$(kubectl get secret -n "$NS" "$app-secret" -o jsonpath='{.data}' \
+        | python3 -c "import sys,json,base64;d=json.load(sys.stdin);print(next(base64.b64decode(v).decode() for k,v in d.items() if 'APIKEY' in k.upper().replace('_','')))")
+  base="http://localhost:$lport/api/$apiver"
+
+  local body
+  body=$(SAB_HOST="$SAB_HOST" SAB_PORT="$SAB_PORT" SAB_API_KEY="$SAB_API_KEY" CAT="$cat" \
+         SCHEMA="$(curl -sf -H "X-Api-Key: $key" "$base/downloadclient/schema")" \
+         EXISTING="$(curl -sf -H "X-Api-Key: $key" "$base/downloadclient")" \
+         python3 - <<'PY'
+import json, os, sys
+
+schema = json.loads(os.environ["SCHEMA"])
+existing = json.loads(os.environ["EXISTING"])
+cat = os.environ["CAT"]
+
+tmpl = next((s for s in schema if s.get("implementation") == "Sabnzbd"), None)
+if tmpl is None:
+    sys.exit("this app's schema has no Sabnzbd implementation")
+
+values = {
+    "host": os.environ["SAB_HOST"],
+    "port": int(os.environ["SAB_PORT"]),
+    "apiKey": os.environ["SAB_API_KEY"],
+    "useSsl": False,
+    "urlBase": "",
+}
+# whichever category field this app happens to define
+for f in tmpl.get("fields", []):
+    if f["name"] in ("tvCategory", "movieCategory", "category") and cat:
+        values[f["name"]] = cat
+
+body = dict(tmpl)
+body["name"] = "SABnzbd"
+body["enable"] = False           # P4 stages it inert. P5 flips this to True.
+body["priority"] = 1
+body["tags"] = []
+body["fields"] = [
+    {**f, "value": values.get(f["name"], f.get("value"))} for f in tmpl.get("fields", [])
+]
+for k in ("removeCompletedDownloads", "removeFailedDownloads"):
+    if k in body:
+        body[k] = True
+
+prior = next((c for c in existing if c.get("implementation") == "Sabnzbd"), None)
+if prior:
+    body["id"] = prior["id"]
+
+print(json.dumps({
+    "body": body,
+    "id": prior["id"] if prior else "",
+    "catfields": [f["name"] for f in tmpl.get("fields", []) if f["name"] in values and "ategory" in f["name"]],
+}))
+PY
+) || { log "  ✗ $app: could not build client body"; kill "$pf_pid" 2>/dev/null; pf_pid=""; return 1; }
+
+  local payload id catf
+  payload=$(python3 -c "import json,sys;d=json.load(sys.stdin);print(json.dumps(d['body']))" <<<"$body")
+  id=$(python3 -c "import json,sys;print(json.load(sys.stdin)['id'])" <<<"$body")
+  catf=$(python3 -c "import json,sys;print(','.join(json.load(sys.stdin)['catfields']) or 'n/a')" <<<"$body")
+
+  if [[ $DRY_RUN -eq 1 ]]; then
+    log "  [dry-run] would $( [[ -n $id ]] && echo update || echo create ) SABnzbd on $app (enable=false, $catf=${cat:-none})"
+    kill "$pf_pid" 2>/dev/null; pf_pid=""; return 0
+  fi
+
+  log "  testing $app -> $SAB_HOST:$SAB_PORT ..."
+  local tcode
+  tcode=$(curl -s -o "/tmp/sabtest.$app" -w '%{http_code}' -X POST -H "X-Api-Key: $key" \
+          -H 'Content-Type: application/json' -d "$payload" "$base/downloadclient/test")
+  if [[ "$tcode" != "200" && "$tcode" != "202" ]]; then
+    log "  ✗ $app: connectivity test FAILED (HTTP $tcode)"
+    head -c 400 "/tmp/sabtest.$app" >&2; echo >&2
+    rc=1
+  else
+    log "  ✓ $app: SABnzbd reachable and authenticated"
+    local scode
+    if [[ -n "$id" ]]; then
+      scode=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "X-Api-Key: $key" \
+              -H 'Content-Type: application/json' -d "$payload" "$base/downloadclient/$id")
+    else
+      scode=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H "X-Api-Key: $key" \
+              -H 'Content-Type: application/json' -d "$payload" "$base/downloadclient")
+    fi
+    case "$scode" in
+      200|201|202) log "  ✓ $app: staged disabled ($catf=${cat:-none})" ;;
+      *)           log "  ✗ $app: save failed (HTTP $scode)"; rc=1 ;;
+    esac
+  fi
+
+  kill "$pf_pid" 2>/dev/null; pf_pid=""
+  return $rc
+}
+
+log "=== P4 pre-stage: SABnzbd as a DISABLED download client ==="
+log "NZBGet stays enabled and untouched. Nothing changes behaviourally."
+log ""
+
+overall=0
+for t in "${TARGETS[@]}"; do
+  IFS=: read -r app port apiver cat <<<"$t"
+  log "$app:"
+  prestage "$app" "$port" "$apiver" "$cat" || overall=1
+  log ""
+done
+
+if [[ $overall -eq 0 ]]; then
+  log "=== all targets staged and connectivity-tested; nothing is live ==="
+else
+  log "=== completed with errors - see above ==="
+fi
+exit $overall


### PR DESCRIPTION
Stands SABnzbd up in-cluster as the replacement for NZBGet on the Synology. **Nothing changes behaviourally in this PR** — NZBGet stays enabled and keeps serving Sonarr/Radarr/Radarr4k until the gated cutover.

Full plan and rationale: `docs/sabnzbd-migration.md`.

## The discovery that made this easy

NZBGet's `/downloads` is `/volume1/media/downloads` — the same NFS export the cluster already mounts. `complete_dir` lands on byte-identical paths, so hardlinks into the library keep working and there is **no data migration**. The `*arr` remote path mappings are keyed to host `10.0.3.2`, so they won't match the in-cluster client and are inert rather than cutover-blocking.

## Storage

- **Incomplete/working set moves to local SSD** — new `longhorn-scratch` class, 250Gi, `numberOfReplicas: 1`, backups excluded. Sized at ~3× the largest observed job (39GB remux) across 150 jobs of history. Keeps par2 repair and unpack off the 1GbE NAS link.
  - At 2 replicas this would consume 500GB against 472/434/348GB of free-to-schedule headroom. Replicating re-downloadable scratch data is waste; node loss just means a re-grab.
  - Honest tradeoff: the move to `complete` stops being a free 5ms rename and becomes a ~6min copy per remux. Measured numbers in §5c.
- **Media share moves off the inline `type: nfs` shortcut** to a static PV, so it can carry `hard,nconnect=8,timeo=600`. `hard` is deliberate — `soft` can corrupt an in-flight unpack.

## Halt on storage loss (both mechanisms, as specified)

- Canary exec probes assert the NAS mount **and** the API on liveness/readiness; a startup probe refuses to start without storage.
- A watchdog sidecar in a shared PID namespace SIGTERMs SABnzbd within ~30s of the mount going away, instead of waiting out a liveness cycle.
- `PrometheusRule` for not-ready, restart storms, and scratch filling.

## Config delivery — encrypted but still UI-editable

Seed-and-**merge**, not overwrite. The full `sabnzbd.ini` lives encrypted in 1Password (`config_seed`); an init container writes it verbatim on first boot (so a PVC loss is fully recoverable from the vault) but on later boots merges **only** the managed keys — servers, categories, folders, tuning — leaving everything SABnzbd wrote for itself alone. Web UI changes persist. `scripts/sabnzbd-export-config.sh` round-trips a deliberate UI change back into the vault.

Every key in the seed was validated against SABnzbd 5.1.2 source before shipping; 4 invented key names were caught and removed that way. The merge logic was tested against simulated UI drift (managed keys revert, unmanaged keys and sections survive).

## ⚠️ Pre-flight finding: 7 of 12 news servers fail authentication

Live `AUTHINFO` testing against all 12:

| Working | Failing |
|---|---|
| NewsDemon, Usenet.farm, NewsGroupNinja, Newshosting (Personal), Tweak (free) | NewsGroup Direct, SuperNews, TweakNews, Newshosting (2nd acct), AstraWeb, UsenetServer-2, EasyNews |

This is very likely the mechanism behind the **27% `FAILURE/HEALTH`** rate in NZBGet's history: seven of the ten servers tried *first* are dead, so every grab burns retries before reaching a working provider.

All 12 are migrated with priorities preserved exactly as configured (the breadth-first ordering is deliberate). The 7 failures ship with `enable = 0` and a note recording the exact error and test date — re-enabling a renewed account is a one-flag change. Also corrected: NewsDemon's port 80 + TLS is **not** a misconfiguration, it genuinely serves TLS on 80 (verified).

## Validation

- `task validate:flux` — 164 passed
- `validate:routes`, `validate:substitutions`, `validate:nfs` — clean
- `validate:secrets` — sabnzbd's 3 fields matched (2 failures in the run are pre-existing and untouched: authentik case mismatch, qbittorrent item missing)
- `validate:security-ctx` — all 3 containers UID 1027 (matches NFS ownership; deliberate departure from the 65534 default)
- `validate:images` — busybox passes; the `ghcr.io/home-operations/sabnzbd:5.1.2` 404 is a validator bug (verified HTTP 200 directly; the same check 404s many untouched ghcr images repo-wide)
- Chart rendered with `helm template` to confirm PVC names, mounts, probes and `shareProcessNamespace`

## What happens after merge

- **P3** — deploy and verify: per-server connection report, one manual test NZB end-to-end, and a deliberate NFS-pull to prove the pod halts and recovers.
- **P4** — `scripts/sabnzbd-prestage-arrs.sh` stages SABnzbd as a **disabled** download client in all three `*arr`s and Prowlarr, and runs each one's built-in connectivity test. Still nothing live.
- **P5** — cutover, gated on your explicit go: flip the enable flags, delete the stale path mappings, retire unpackerr.

https://claude.ai/code/session_011NsKzUJosLzTax4aizZgF7