### PR TITLE
fix(matrix-media-relay): dress ghosts at startup, not inside the first send

### DIFF
--- a/docs/matrix-webhooks.md
+++ b/docs/matrix-webhooks.md
@@ -105,9 +105,36 @@ logged at startup and skipped rather than left open.
 3. Drop the icon PNG next to `relay.py`, add it to the `matrix-media-relay-avatars`
    generator and its mount, and reference it as `"avatar"` on the profile.
 
-That is the whole procedure for a **public** room: on first use the relay
+That is the whole procedure for a **public** room: at startup the relay
 registers the ghost and joins it to every room in its profile, because Synapse
 rejects a send from a non-member with 403 regardless of the join rule.
+
+**Identity is applied at startup, not on first send, and that ordering is
+load-bearing.** `PUT /profile/{user}/avatar_url` returns as soon as the profile
+row is written; Synapse then fans the change out into an `m.room.member` event
+per room *in the background*. Clients render a message's sender from the member
+state **at that event**, so a send that beats the fan-out is displayed with no
+avatar — permanently, because the timeline is immutable. Doing it lazily inside
+the first request lost that race every time, which is why the first Uptime Kuma,
+Longhorn and Cloudflare messages show letter avatars and always will:
+
+```
+01:33:15 _uptimekuma  MEMBER   avatar=NO -> NO
+01:33:15 _uptimekuma  MESSAGE  ✅ Up - relay round-trip test      <- no avatar
+01:33:15 _uptimekuma  MEMBER   avatar=NO -> yes                  <- 200ms too late
+```
+
+`prepare_profiles()` now runs before the listener opens, and
+`_await_member_avatar` polls the room member event until the new `mxc://`
+actually appears (`MEMBER_SYNC_TIMEOUT`, default 10s). It is only paid when an
+avatar genuinely changed, so a normal restart waits for nothing. The readiness
+probe is what makes a synchronous startup safe: nothing is routed to the pod
+until the HTTP server is up. The timeout is bounded well inside the liveness
+budget (~100s) even if every profile changed at once, and a timeout is logged
+and ignored — a missing icon is worth far less than a dropped notification.
+
+**Note this cannot be repaired retroactively.** There is no way to refresh the
+icon on an already-sent message; only new messages pick up current state.
 
 An **invite-only** room still needs the ghost invited first — the join call
 accepts a pending invite but cannot manufacture one. The failure is logged with

--- a/kubernetes/apps/tools/matrix-media-relay/app/relay.py
+++ b/kubernetes/apps/tools/matrix-media-relay/app/relay.py
@@ -14,8 +14,8 @@ Callers are identified by a per-profile bearer token. The profile -- not the
 request -- decides which ghost sends and which rooms are reachable, so a leaked
 token cannot be used to post as someone else or into an unrelated room. Add a
 profile plus its TOKEN_<NAME> to onboard another notification source; the ghost
-registers and joins its rooms on first use, so a public room needs no manual
-step at all.
+registers, joins its rooms and applies its name and icon at startup, before the
+listener opens, so a public room needs no manual step at all.
 
 Stdlib only, so it runs on a stock python image with no build step.
 """
@@ -47,6 +47,10 @@ IMAGE_HOSTS = {h.strip().lower() for h in
 # Account-data key holding the hash of the avatar we last applied, so the
 # image is only re-uploaded when it actually changes.
 AVATAR_STATE = "uk.co.matrix-media-relay.avatar"
+# How long to wait at startup for a freshly-set avatar to reach a room's member
+# event. Only paid when an avatar actually changed, so normally zero.
+MEMBER_SYNC_TIMEOUT = float(os.environ.get("MEMBER_SYNC_TIMEOUT", "10"))
+MEMBER_SYNC_INTERVAL = 0.5
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger("relay")
@@ -212,6 +216,9 @@ def _ensure_avatar(sender, filename):
 
     Hookshot rewrites display names but never touches avatars, so what is set
     here survives its restarts.
+
+    Returns (mxc, changed). `changed` is what tells the caller whether it is
+    worth waiting for the new avatar to reach room member events.
     """
     path = os.path.join(AVATAR_DIR, filename)
     try:
@@ -219,13 +226,14 @@ def _ensure_avatar(sender, filename):
             data = handle.read()
     except OSError as exc:
         log.warning("avatar %s unreadable: %s", path, exc)
-        return
+        return None, False
     digest = hashlib.sha256(data).hexdigest()
     state_path = "/_matrix/client/v3/user/%s/account_data/%s" % (
         urllib.parse.quote(sender), AVATAR_STATE)
     try:
-        if _matrix("GET", state_path, sender).get("sha256") == digest:
-            return
+        cached = _matrix("GET", state_path, sender)
+        if cached.get("sha256") == digest:
+            return cached.get("mxc"), False
     except urllib.error.HTTPError as exc:
         if exc.code != 404:  # 404 simply means we have never set one
             log.warning("reading avatar state for %s: %s", sender, exc)
@@ -236,8 +244,41 @@ def _ensure_avatar(sender, filename):
                 sender, {"avatar_url": mxc})
         _matrix("PUT", state_path, sender, {"sha256": digest, "mxc": mxc})
         log.info("avatar for %s set to %s", sender, mxc)
+        return mxc, True
     except Exception:
         log.exception("could not set avatar for %s", sender)
+        return None, False
+
+
+def _await_member_avatar(sender, room, mxc):
+    """Block until the ghost's avatar has reached this room's member event.
+
+    Setting `avatar_url` on the profile returns as soon as the profile is
+    written; Synapse then fans the change out into an m.room.member event per
+    room in the background. Clients render a message's sender from the member
+    state *at that event*, so a send that wins this race is displayed with no
+    avatar -- permanently, because the timeline is immutable. Waiting here is
+    what stops the first notification from a new ghost being the ugly one.
+
+    Bounded and best-effort: a timeout is logged and ignored, since a missing
+    icon is worth far less than a notification that never arrives.
+    """
+    path = "/_matrix/client/v3/rooms/%s/state/m.room.member/%s" % (
+        urllib.parse.quote(room), urllib.parse.quote(sender))
+    deadline = time.time() + MEMBER_SYNC_TIMEOUT
+    while time.time() < deadline:
+        try:
+            if _matrix("GET", path, sender).get("avatar_url") == mxc:
+                return True
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:  # 404 = not a member yet, keep waiting
+                log.warning("reading member state for %s in %s: %s", sender, room, exc)
+        except Exception:
+            log.exception("reading member state for %s in %s", sender, room)
+        time.sleep(MEMBER_SYNC_INTERVAL)
+    log.warning("avatar for %s did not reach %s within %ss; its next message may "
+                "render without an icon", sender, room, MEMBER_SYNC_TIMEOUT)
+    return False
 
 
 def _ensure_identity(profile):
@@ -247,7 +288,32 @@ def _ensure_identity(profile):
     if profile.get("displayname"):
         _ensure_displayname(profile["sender"], profile["displayname"])
     if profile.get("avatar"):
-        _ensure_avatar(profile["sender"], profile["avatar"])
+        return _ensure_avatar(profile["sender"], profile["avatar"])
+    return None, False
+
+
+def prepare_profiles():
+    """Dress every ghost before the listener opens.
+
+    Doing this lazily on the first send is what produced permanently
+    icon-less first messages: register, join, name and avatar all happened
+    inside the request that then immediately posted. Running it at startup
+    means the race is against nothing -- there is no traffic yet -- and the
+    wait above only costs anything the once, when an avatar actually changed.
+
+    Failures here are logged and swallowed on purpose. The per-send path still
+    calls _ensure_identity, so a Synapse that is briefly unreachable at boot
+    degrades to the old behaviour instead of crash-looping the relay.
+    """
+    for profile in PROFILES.values():
+        try:
+            mxc, changed = _ensure_identity(profile)
+            if changed and mxc:
+                for room in profile["rooms"]:
+                    _await_member_avatar(profile["sender"], room, mxc)
+        except Exception:
+            log.exception("preparing profile %s failed; it will be retried on "
+                          "first use", profile["name"])
 
 
 def _read_image(resp, source):
@@ -389,5 +455,9 @@ if __name__ == "__main__":
         log.error("no usable profiles; every request will be rejected")
     for p in PROFILES.values():
         log.info("profile %s -> %s rooms=%s", p["name"], p["sender"], p["rooms"])
+    # Before the listener opens, so no request can race a half-dressed ghost.
+    # The readiness probe is what makes this safe to do synchronously: the pod
+    # is not marked ready, and nothing is routed to it, until this returns.
+    prepare_profiles()
     log.info("listening on :%d", PORT)
     ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()


### PR DESCRIPTION
A brand-new ghost's **first** notification renders with a letter avatar — and always will, because Matrix timelines are immutable.

## Not a cache

Server state was correct the whole time. Profile, room member event, original media and thumbnail all verified good for all five ghosts. The cause is event ordering:

```
01:33:15 _uptimekuma  MEMBER   avatar=NO -> NO
01:33:15 _uptimekuma  MESSAGE  relay round-trip test      <- rendered with no avatar
01:33:15 _uptimekuma  MEMBER   avatar=NO -> yes           <- 200ms too late
```

`PUT /profile/{user}/avatar_url` returns as soon as the profile row is written. Synapse *then* fans the change into an `m.room.member` event per room, in the background. Clients render a message's sender from the member state **at that event** — so a send that beats the fan-out is displayed without an avatar permanently.

`_ensure_identity` did register → join → displayname → avatar lazily, inside the very request that then posted. It lost that race every time.

Alertmanager and Forgejo look right only because their avatars were set ~30 minutes before either ever posted.

## Fix

- `prepare_profiles()` runs **before the listener opens**, so the race is against no traffic at all.
- `_await_member_avatar` polls the room member event until the new `mxc://` actually lands (`MEMBER_SYNC_TIMEOUT`, default 10s).

The wait is only paid when an avatar genuinely **changed** — `_ensure_avatar` now returns `(mxc, changed)` — so an ordinary restart waits for nothing.

## Why synchronous startup is safe here

The readiness probe: nothing is routed to the pod until the HTTP server is up. Worst case is 5 profiles × 10s = 50s, comfortably inside the ~100s liveness budget (`initialDelay 10` + `period 30` × `failureThreshold 3`), and that only if every avatar changed at once.

Failures are logged and swallowed, not raised. The per-send path still calls `_ensure_identity`, so a Synapse that is briefly unreachable at boot degrades to the old behaviour instead of crash-looping the relay.

## Called out

**This does not repair the existing lettered messages, and nothing can.** There is no way to refresh a sender's icon on an already-sent event; only new messages pick up current state. The three fresh test messages sent just before this PR should already render correctly — that is the confirmation that current state is fine and only history is affected.

## Verification

`py_compile` clean, `kustomize build` clean. Behaviour verified post-merge by checking the relay logs show identity work before `listening on :8080`.

https://claude.ai/code/session_019w5uxERaapQARbTHmHSiNX