### PR TITLE
docs(matrix-webhooks): record the HelmRelease that stalled for six days

### DIFF
--- a/docs/matrix-webhooks.md
+++ b/docs/matrix-webhooks.md
@@ -373,6 +373,60 @@ means the registration `url` points at the webhooks listener (9000) instead of
 the appservice port (9993). Anything else means the bridge is fine; ignore the
 warning.
 
+## Trap: a HelmRelease whose *first* install failed stalls forever
+
+Found 2026-09-02, six days after the fact. Hookshot's pod was healthy and every
+webhook worked, but `flux get helmreleases -n tools` showed:
+
+```
+Stalled   True   MissingRollbackTarget  Failed to perform remediation:
+                 missing target release for rollback: cannot remediate failed release
+Ready     False  UpgradeFailed
+```
+
+`helm -n tools history hookshot` told the story:
+
+```
+1  Aug 27 23:44  failed  Release "hookshot" failed: timeout waiting for: [Deployment/tools/hookshot status: 'InProgress']
+2  Aug 27 23:54  failed  Upgrade "hookshot" failed: failed early due to stalled resources: [Deployment/tools/hookshot status: 'Failed']
+```
+
+Both attempts landed inside the ~95 minute Synapse outage documented below, so
+the Deployment never went Ready in time. **The install itself failed**, which
+means there was never a `deployed` revision — and with no good revision to roll
+back to, Flux's remediation cannot run, sets `Stalled`, and **stops retrying
+permanently**. It does not self-heal even after the underlying problem is fixed.
+
+This is the nasty part: **nothing looks broken.** The pod runs, the bridge
+works, notifications deliver. The only symptom is a HelmRelease that quietly
+stopped being managed. The consequence only arrives later — evict or reschedule
+that pod and Flux will not bring it back.
+
+Recovery, once the underlying cause is actually fixed:
+
+```sh
+flux -n tools reconcile helmrelease hookshot --force
+```
+
+`--force` is required specifically because `Stalled` means Flux will not retry
+on its own. This produced `revision 3 ... deployed` with **no pod restart** —
+Helm applied an identical spec, so nothing rolled. Chart version was unchanged
+(`5.0.1` in `ocirepository.yaml`, same as both failed attempts), so this was
+purely Helm bookkeeping catching up with reality.
+
+If `--force` is not enough, the next step is deleting the failed release secrets
+(`kubectl -n tools delete secret -l owner=helm,name=hookshot`) and letting Flux
+install fresh — the live resources carry `meta.helm.sh/release-name` and
+`app.kubernetes.io/managed-by: Helm`, so Helm 3 **adopts** them rather than
+colliding. Verify those annotations are present before trying it.
+
+**Worth checking periodically**, since this failure mode is invisible from the
+application side:
+
+```sh
+flux get helmreleases -A --status-selector ready=false
+```
+
 ## Trap: ESO and Helm apply the appservice change separately
 
 This took Synapse down for ~95 minutes on first deploy. It will recur on a


### PR DESCRIPTION
Docs-only. The fix is already applied — hookshot's HelmRelease is `Ready: True` with a `deployed` revision.

## What was wrong

Hookshot's HelmRelease had been `Stalled` since **2026-08-27** and nothing on the application side showed it. Pod healthy, bridge answering, every webhook delivering.

```
Stalled  True  MissingRollbackTarget  missing target release for rollback: cannot remediate failed release
Ready    False UpgradeFailed
```

`helm history` explains it:

```
1  Aug 27 23:44  failed  timeout waiting for: [Deployment/tools/hookshot status: 'InProgress']
2  Aug 27 23:54  failed  failed early due to stalled resources: [Deployment/tools/hookshot status: 'Failed']
```

Both attempts landed inside the ~95 minute Synapse outage already documented in this file, so the Deployment never went Ready in time. **The install itself failed**, so there was never a `deployed` revision — and with no rollback target, Flux's remediation can't run, sets `Stalled`, and **stops retrying permanently**. It does not self-heal once the underlying problem is gone.

## Why it mattered

The consequence was deferred, not immediate. Evict or reschedule that pod and **Flux would not have brought it back** — taking all five Infrastructure notification sources with it. Six days of a service that looked fine and was silently unmanaged.

## Fix applied

```sh
flux -n tools reconcile helmrelease hookshot --force
```

`--force` is required specifically because `Stalled` suppresses the normal retry.

Result: `revision 3 ... deployed`, **no pod restart** — chart version was unchanged (`5.0.1`, same as both failed attempts), so Helm applied an identical spec and nothing rolled. Purely bookkeeping catching up with reality.

Verified after:

| Check | Result |
|---|---|
| `Ready` / `Released` | True / UpgradeSucceeded |
| `Stalled` condition | gone |
| Pod | same pod, never restarted |
| Webhook round-trip | 202 `{"ok":true}` |
| `/live`, `/ready` | `{"ok":true}`, `{"ready":true}` |

## Also documented

- The fallback if `--force` isn't enough: delete the failed release secrets and let Helm 3 **adopt** the live resources via their `meta.helm.sh/release-name` annotations (verified present before recommending it).
- `flux get helmreleases -A --status-selector ready=false` — the query that surfaces this class of failure, since the application side gives no signal.

## Not addressed

`tools/artifacts` and `tools/bridge` have been not-Ready since 2026-07-19 with a different reason (`RollbackSucceeded`) — out of scope per your call.

https://claude.ai/code/session_019w5uxERaapQARbTHmHSiNX