### PR TITLE
fix(sabnzbd): size scratch volume to what Longhorn can actually schedule

### DIFF
--- a/docs/sabnzbd-migration.md
+++ b/docs/sabnzbd-migration.md
@@ -236,8 +236,20 @@ Your instinct was right — the tail is entirely 1080p BluRay remuxes at 32–39
 - **Queue burst headroom:** a couple more large movies or a full season pack queued → **+80 G**
 - **`download_free` guard:** SAB pauses rather than filling the volume → **+40 G**
 
-**Recommendation: a 250Gi PVC.** That is ~3× the single-job worst case and covers a realistic burst of
+**Planned: a 250Gi PVC.** That is ~3× the single-job worst case and covers a realistic burst of
 4–5 remuxes in flight, with SAB pausing (not failing) if it somehow gets deeper than that.
+
+**Corrected at deploy time (P3): 150Gi.** The 250Gi volume would not schedule. Longhorn does not
+schedule against raw free disk (~695 GB/node) but against
+`storageMaximum - storageReserved - storageScheduled`, and the default 30% reservation (247 GB/node)
+leaves only **223 / 186 / 100 GB** schedulable. 150Gi fits on two nodes, so the volume can still
+reschedule if one is drained; 200Gi would have fit only `asgard-mpc-01` and pinned the workload there.
+`download_free` drops 40G → 25G to match the smaller volume (leaving ~125 GB usable). The class sets
+`allowVolumeExpansion: true`, so this grows in place once local SSD is expanded — no migration needed.
+
+Practical effect at 150Gi: a single 39 GB RAR'd remux (≈80 GB with its extracted output) still has room
+alongside a second job downloading. Back-to-back remuxes may briefly pause the queue on the free-space
+guard, which is safe behaviour, not failure.
 
 **On a new `longhorn-scratch` StorageClass — `numberOfReplicas: "1"`, backups excluded.** This matters:
 

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -185,13 +185,18 @@ spec:
               - path: /config
             config-backup:
               - path: /config
-      # Incomplete/working set on local SSD, off the NAS link. Sized at ~3x the
-      # largest observed job (39GB remux); see docs/sabnzbd-migration.md §5c.
+      # Incomplete/working set on local SSD, off the NAS link.
+      # 150Gi, not the 250Gi originally planned: Longhorn schedules against
+      # (storageMaximum - storageReserved - storageScheduled), and the default 30%
+      # reservation leaves only 223/186/100 GB schedulable across the three nodes.
+      # 150Gi fits on two of them, so the volume can still reschedule if a node is
+      # drained. Expandable in place (allowVolumeExpansion) once local SSD grows.
+      # See docs/sabnzbd-migration.md §5c.
       scratch:
         type: persistentVolumeClaim
         storageClass: longhorn-scratch
         accessMode: ReadWriteOnce
-        size: 250Gi
+        size: 150Gi
         advancedMounts:
           sabnzbd:
             seed-config:


### PR DESCRIPTION
Unblocks the P3 deploy. The 250Gi scratch PVC from #555 could not schedule a replica:

```
volume is currently in detached state with some un-schedulable replicas
precheck new replica failed: insufficient storage
```

**Cause:** Longhorn schedules against `storageMaximum - storageReserved - storageScheduled`, not raw free disk. The default 30% reservation is 247GB/node, so despite ~695GB actually free per node, only this much is schedulable:

| node | max | reserved | scheduled | schedulable |
|---|---|---|---|---|
| asgard-mpc-01 | 824G | 247G | 353G | **223G** |
| asgard-mpc-02 | 824G | 247G | 391G | **186G** |
| asgard-mpc-03 | 824G | 247G | 476G | **100G** |

My original sizing read `storageAvailable` and missed the reservation.

**Fix:** 150Gi. It fits on two nodes, so the volume can still reschedule if one is drained — 200Gi would have fit only `asgard-mpc-01` and pinned the workload there. `download_free` drops 40G → 25G in the 1Password seed to match, leaving ~125GB usable.

At 150Gi a single 39GB RAR'd remux (~80GB with its extracted output) still has room alongside a second job downloading; back-to-back remuxes may briefly pause on the free-space guard, which is safe behaviour rather than failure. `allowVolumeExpansion: true` is already set, so this grows in place once local SSD is expanded — no migration.

`task validate:flux` — 164 passed.

https://claude.ai/code/session_011NsKzUJosLzTax4aizZgF7