### PR TITLE
fix(sabnzbd): write api_key, nzb_key and host_whitelist from the environment

### DIFF
--- a/docs/sabnzbd-migration.md
+++ b/docs/sabnzbd-migration.md
@@ -371,6 +371,21 @@ in §4, failure detection in §5d), and local scratch storage is now in scope (�
 
 ---
 
+## 8a. P3 deployment defects found and fixed
+
+Recorded because each was a real design error, not a transient:
+
+| # | Defect | Cause | Fix |
+|---|---|---|---|
+| 1 | 250Gi scratch PVC would not schedule | Sized against Longhorn's `storageAvailable` (raw free disk) instead of `storageMaximum - storageReserved - storageScheduled`; the default 30% reservation leaves 223/186/100 GB schedulable | 150Gi, fits two nodes; `download_free` 40G → 25G (#559) |
+| 2 | SABnzbd generated its own random `api_key`, ignoring the one in 1Password | The seed omitted `api_key`/`nzb_key`/`host_whitelist` on the assumption the image's entrypoint would inject them. Its `sed` only *substitutes into lines that already exist*, so with no line to match it silently did nothing and SABnzbd invented a key on first start | The init container now writes all three from the environment itself, after the merge — no reliance on image internals |
+| 3 | `host_whitelist` contained only the pod name | Same root cause; SABnzbd auto-added its own hostname when the key was absent, which would have broken access via the route hostname | As above |
+| 4 | Watchdog log printed "every s" | `${INTERVAL}` in the ConfigMap was consumed by Flux variable substitution — the documented gotcha in `AGENTS.md`; cosmetic only, the `sleep` used the unbraced form | Unbraced `$INTERVAL` |
+| 5 | `config-backup` logged "tar failed" then slept 24h | Ran before SABnzbd had created `/config/admin`, and any failure cost a full day | 120s startup delay, tolerates a missing `admin/`, retries in 10m on failure |
+
+Defects 2 and 3 would have surfaced as a broken cutover rather than a broken deploy: SABnzbd looked healthy,
+but every `*arr` would have failed to authenticate against it.
+
 ## 9. Open items
 
 None blocking. P1 through P4 can run unattended once the P2 PR is approved; P5 waits on your explicit go.

--- a/kubernetes/apps/media/sabnzbd/app/configmap.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/configmap.yaml
@@ -26,6 +26,17 @@ data:
     SEED = "/seed/sabnzbd.ini.seed"
     INI = "/config/sabnzbd.ini"
 
+    # Written from the environment (ExternalSecret / HelmRelease), never from the
+    # seed. The upstream entrypoint tries to sed these in, but its sed only
+    # matches lines that already exist - and a seed that omits them leaves
+    # SABnzbd free to generate its own random api_key and to whitelist nothing
+    # but the pod name, which breaks both the *arrs and the route.
+    FROM_ENV = {
+        "api_key": "SABNZBD__API_KEY",
+        "nzb_key": "SABNZBD__NZB_KEY",
+        "host_whitelist": "SABNZBD__HOST_WHITELIST_ENTRIES",
+    }
+
     MANAGED_SECTIONS = {"servers", "categories"}
     MANAGED_MISC = {
         "download_dir", "complete_dir", "dirscan_dir", "script_dir",
@@ -74,6 +85,35 @@ data:
             block.pop()
         return block
 
+    def apply_env(path):
+        """Force the identity keys in [misc] to match the environment."""
+        want = {k: os.environ[e] for k, e in FROM_ENV.items() if os.environ.get(e)}
+        if not want:
+            print("WARNING: none of %s are set - SABnzbd will invent its own"
+                  % ", ".join(FROM_ENV.values()))
+            return
+        lines, seen, sec = open(path).read().splitlines(), set(), None
+        out = []
+        for line in lines:
+            t = line.strip()
+            if t.startswith("[") and not t.startswith("[["):
+                sec = t[1:-1]
+            key = t.split("=")[0].strip() if "=" in t and not t.startswith("[") else None
+            if sec == "misc" and key in want:
+                out.append("%s = %s" % (key, want[key]))
+                seen.add(key)
+                continue
+            out.append(line)
+        missing = [k for k in want if k not in seen]
+        if missing:
+            for i, line in enumerate(out):
+                if line.strip() == "[misc]":
+                    for k in missing:
+                        out.insert(i + 1, "%s = %s" % (k, want[k]))
+                    break
+        open(path, "w").write("\n".join(out) + "\n")
+        print("identity keys applied from env: %s" % ", ".join(sorted(want)))
+
     def main():
         if not os.path.exists(SEED):
             sys.exit("seed not present at %s - is the ExternalSecret synced?" % SEED)
@@ -83,6 +123,7 @@ data:
             os.makedirs(os.path.dirname(INI), exist_ok=True)
             open(INI, "w").write(seed_text)
             print("no existing sabnzbd.ini - wrote seed verbatim (%d bytes)" % len(seed_text))
+            apply_env(INI)
             return
 
         shutil.copy2(INI, INI + ".bak-" + time.strftime("%Y%m%d-%H%M%S"))
@@ -135,6 +176,7 @@ data:
         print("merged seed into existing sabnzbd.ini; %d change(s)" % len(changed))
         for c in changed:
             print("  " + c)
+        apply_env(INI)
 
     main()
 
@@ -149,7 +191,7 @@ data:
     INTERVAL=15
     FAILURES=0
     THRESHOLD=2
-    echo "[watchdog] armed: checking $CANARY every ${INTERVAL}s, halt after $THRESHOLD consecutive failures"
+    echo "[watchdog] armed: checking $CANARY every $INTERVAL""s, halt after $THRESHOLD consecutive failures"
     while true; do
       if timeout 10 test -e "$CANARY" 2>/dev/null; then
         if [ "$FAILURES" -ne 0 ]; then

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -22,6 +22,17 @@ spec:
             image:
               repository: ghcr.io/home-operations/sabnzbd
               tag: 5.1.2
+            env:
+              SABNZBD__HOST_WHITELIST_ENTRIES: >-
+                sabnzbd,
+                sabnzbd.media,
+                sabnzbd.media.svc,
+                sabnzbd.media.svc.cluster,
+                sabnzbd.media.svc.cluster.local,
+                sabnzbd.${SECRET_DOMAIN}
+            envFrom:
+              - secretRef:
+                  name: sabnzbd-secret
             command:
               - /bin/sh
               - -c
@@ -112,19 +123,27 @@ spec:
               - -c
               - |
                 DEST=/data/media/.backups/sabnzbd
+                # Let SABnzbd finish creating /config/admin on a cold start.
+                sleep 120
                 while true; do
+                  NEXT=86400
                   if mkdir -p "$DEST" 2>/dev/null; then
                     TS=$(date +%Y%m%d-%H%M%S)
-                    if tar czf "$DEST/sabnzbd-config-$TS.tar.gz" -C /config sabnzbd.ini admin 2>/dev/null; then
-                      echo "[config-backup] wrote $DEST/sabnzbd-config-$TS.tar.gz"
+                    SRC="sabnzbd.ini"
+                    [ -d /config/admin ] && SRC="$SRC admin"
+                    if tar czf "$DEST/sabnzbd-config-$TS.tar.gz" -C /config $SRC 2>/dev/null; then
+                      echo "[config-backup] wrote $DEST/sabnzbd-config-$TS.tar.gz ($SRC)"
                       find "$DEST" -name 'sabnzbd-config-*.tar.gz' -type f -mtime +14 -print -delete
                     else
-                      echo "[config-backup] tar failed - skipping this cycle"
+                      echo "[config-backup] tar failed - retrying in 10m"
+                      rm -f "$DEST/sabnzbd-config-$TS.tar.gz"
+                      NEXT=600
                     fi
                   else
-                    echo "[config-backup] destination unreachable - skipping this cycle"
+                    echo "[config-backup] destination unreachable - retrying in 10m"
+                    NEXT=600
                   fi
-                  sleep 86400
+                  sleep "$NEXT"
                 done
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Second P3 fix. SABnzbd deployed and came up 3/3 healthy — but with **an API key it generated itself rather than the one in 1Password**, and a `host_whitelist` containing only the pod name.

This would not have shown up as a broken deploy. It would have shown up at cutover, with every `*arr` failing to authenticate.

## Cause

The seed deliberately omitted `api_key`, `nzb_key` and `host_whitelist`, on the assumption that the upstream entrypoint would inject them from the `SABNZBD__*` env vars. It does try — but its `sed` only substitutes into lines that **already exist**:

```sh
[[ -n "${SABNZBD__API_KEY}" ]] && sed -i -e "s|^api_key *=.*$|api_key = ${SABNZBD__API_KEY}|g" /config/sabnzbd.ini
```

With no `api_key` line in the seed there was nothing to match, so it was a silent no-op and SABnzbd invented a random key on first start. Same for `host_whitelist` — SABnzbd then auto-added its own hostname, giving `host_whitelist = sabnzbd-7bcc58686b-77fb8,` and nothing else.

## Fix

The init container now applies all three from its own environment after the merge, so correctness no longer depends on image internals. Verified against both a cold start and a warm start where SABnzbd had already regenerated its own key — 9/9 assertions, including that the keys land in `[misc]` only and aren't duplicated.

## Also fixed

- **watchdog logged `every s`** — `${INTERVAL}` in the ConfigMap was consumed by Flux variable substitution (the gotcha documented in `AGENTS.md`). Cosmetic only: the `sleep` used the unbraced form and was always correct.
- **`config-backup` logged "tar failed" then slept 24h** — it ran before SABnzbd had created `/config/admin`. Now waits 120s on cold start, tolerates a missing `admin/`, and retries in 10m instead of a day.

`task validate:flux` — 164 passed. `validate:substitutions` clean.

Cluster state: SABnzbd 3/3 Running, scratch bound at 150Gi, all 12 servers and 6 categories loaded from the seed with the 7 dead ones disabled. NZBGet untouched and still serving.

https://claude.ai/code/session_011NsKzUJosLzTax4aizZgF7