### PR TITLE
refactor(hermes-agent): drop the retired Mattermost adapter

### DIFF
--- a/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/externalsecret-dotenv.yaml
@@ -19,27 +19,20 @@ spec:
         # still deferred — add fields to the hermes-dotenv 1Password item and
         # reference them here when enabling.
         #
-        # Matrix cutover (2026-07-17) was originally meant to replace the
-        # Mattermost adapter, but Shawn decided (2026-07-19) to run both side
-        # by side while he evaluates dropping Matrix later — so both
-        # platform blocks are wired here. The gateway auto-enables each
-        # bundled adapter purely from its own env vars being present
-        # (MATTERMOST_URL/MATTERMOST_TOKEN and MATRIX_HOMESERVER/
-        # MATRIX_ACCESS_TOKEN respectively); no HelmRelease/config.yaml
-        # change needed to run both at once.
-        #
-        # Mattermost: bot account "hermes" in the mixos team, open to any
-        # user in this internal-only instance; MATTERMOST_HOME_CHANNEL is
-        # the dedicated #hermes-home channel for cron/proactive delivery;
-        # MATTERMOST_REPLY_MODE=thread keeps @mention/channel replies in the
-        # originating thread instead of posting new root messages.
+        # Matrix is the only messaging platform. The 2026-07-17 cutover ran
+        # side by side with Mattermost until Mattermost was decommissioned,
+        # so the MATTERMOST_* block is deliberately absent here. The gateway
+        # auto-enables each bundled adapter purely from its own env vars
+        # being present — leaving those variables set is what kept the
+        # retired adapter dialling mattermost-main:8065, so removing them is
+        # the entire off switch. No HelmRelease/config.yaml change needed.
         #
         # Matrix: bot @hermes lives on the internal Synapse (auth delegated
         # to MAS; token is a MAS compatibility token). Access is allowlisted
-        # to Shawn instead of Mattermost's allow-all; MATRIX_HOME_ROOM is the
-        # private #hermes-home room for cron/proactive delivery.
-        # SESSION_SCOPE=room isolates context per room; AUTO_THREAD mirrors
-        # Mattermost's REPLY_MODE=thread. E2EE off: internal-only traffic,
+        # to Shawn; MATRIX_HOME_ROOM is the private #hermes-home room for
+        # cron/proactive delivery. SESSION_SCOPE=room isolates context per
+        # room; AUTO_THREAD keeps replies in the originating thread instead
+        # of posting new root messages. E2EE off: internal-only traffic,
         # plain HTTP inside the cluster.
         #
         # Dashboard SSO (2026-07-19): v2026.7.x hardened the dashboard
@@ -60,11 +53,6 @@ spec:
         # the redirect_uri pinned in the Authentik hermes-oidc blueprint.
         .env: |
           API_SERVER_KEY={{ .API_SERVER_KEY }}
-          MATTERMOST_URL=http://mattermost-main.tools.svc.cluster.local:8065
-          MATTERMOST_TOKEN={{ .MATTERMOST_TOKEN }}
-          MATTERMOST_ALLOW_ALL_USERS=true
-          MATTERMOST_HOME_CHANNEL=4qkyyzxfejdtuqpdkkiatbemur
-          MATTERMOST_REPLY_MODE=thread
           MATRIX_HOMESERVER=http://synapse-main.tools.svc.cluster.local:8008
           MATRIX_ACCESS_TOKEN={{ .MATRIX_ACCESS_TOKEN }}
           MATRIX_USER_ID=@hermes:matrix.${SECRET_DOMAIN}
@@ -82,10 +70,6 @@ spec:
       remoteRef:
         key: hermes-dotenv
         property: password
-    - secretKey: MATTERMOST_TOKEN
-      remoteRef:
-        key: hermes-dotenv
-        property: MATTERMOST_TOKEN
     - secretKey: MATRIX_ACCESS_TOKEN
       remoteRef:
         key: hermes-dotenv

--- a/kubernetes/apps/database/postgres/app/prometheusrule.yaml
+++ b/kubernetes/apps/database/postgres/app/prometheusrule.yaml
@@ -1,7 +1,7 @@
 ---
 # Discovered automatically: kube-prometheus-stack sets
 # ruleSelectorNilUsesHelmValues: false, so PrometheusRules in any namespace are
-# picked up. Alerts deliver to Mattermost via the alertmanager config secret.
+# picked up. Alerts deliver to Matrix via the alertmanager config secret.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -78,13 +78,13 @@ spec:
     alertmanager:
       enabled: true
       alertmanagerSpec:
-        # Public-facing URL so the "receiver" link in every Mattermost alert
+        # Public-facing URL so the "receiver" link in every Matrix alert
         # resolves from a browser instead of http://kps-alertmanager...:9093.
         # Route: kubernetes/.../kube-prometheus-stack httproute (alertmanager.<domain>).
         externalUrl: https://alertmanager.${SECRET_DOMAIN}
         # Full config rendered by the alertmanager ExternalSecret. Delivery is
-        # Mattermost #infrastructure via a Slack-compatible incoming webhook
-        # (api_url inline; the operator's parser rejects *_file indirection).
+        # the Matrix Infrastructure room via a matrix-hookshot generic webhook
+        # (url inline; the operator's parser rejects *_file indirection).
         configSecret: alertmanager-config
         storage:
           volumeClaimTemplate:


### PR DESCRIPTION
Phase 1 of the Mattermost decommission — cut the last producer. Nothing is deleted; Mattermost keeps running but goes quiet.

## The adapter was never actually off

The Matrix cutover was meant to end Mattermost delivery, but hermes held a live WebSocket to `mattermost-main:8065` right up until this commit:

```
10.43.109.146  8008   <- synapse
10.43.59.41    8065   <- mattermost
```

The gateway auto-enables each bundled adapter purely from its own env vars being present, and `externalsecret-dotenv.yaml` still rendered all five `MATTERMOST_*` variables into `.env`. Every ESO resync restored them. There is no HelmRelease or `config.yaml` flag to clear — removing the variables is the entire off switch.

## Changes

- `hermes-agent/app/externalsecret-dotenv.yaml` — drop the five `MATTERMOST_*` env lines and the `MATTERMOST_TOKEN` remoteRef; rewrite the comment block to describe Matrix as the only platform.
- `kube-prometheus-stack/app/helmrelease.yaml`, `database/postgres/app/prometheusrule.yaml` — comments still said alerts deliver to Mattermost. They have gone to the Matrix Infrastructure room via a matrix-hookshot generic webhook since the notification-webhooks work.

## Validation

`validate:flux`, `validate:secret-keys`, `validate:substitutions`, `validate:hermes-patch` pass. Three pre-existing failures are unrelated and reproduce on a clean tree: `validate:static` (repo-wide yamllint debt in `media/*`), `validate:secrets` (`authentik-secret`, `qbittorrent` 1P items), `validate:rendered` (locally installed flux-local 8.4.0 dropped `--enable-helm`).

## Verify after merge

hermes's connection to `10.43.59.41:8065` should be gone; Matrix delivery unaffected.

https://claude.ai/code/session_01TguebKLBcer1vQEEP7ot61