### PR TITLE
docs(mattermost): clear the references the decommission left behind

### DIFF
--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -111,7 +111,6 @@ front of it - for an internal-only route that is a deliberate choice, not an omi
 | Plex | internal | `external_identity_exception` | Uses Plex.tv identity model |
 | Authentik | external | `public_exception` | It is the IdP. Admin console is 404'd at the public edge |
 | Echo, Flux webhook, Tesla pubkey | external | `public_exception` | Webhook and probe endpoints |
-| Mattermost | internal | `none` | Team Edition licence-gates OIDC; internal-only LAN access |
 | Grimmory | internal | `none` | OIDC explicitly disabled in its config |
 | All other internal apps | internal | `none` | Internal-only; no gateway auth and no OIDC configured |
 

--- a/docs/hermes-memory-patch.md
+++ b/docs/hermes-memory-patch.md
@@ -19,10 +19,14 @@ Hermes keeps two built-in memory files under its home directory:
 | `MEMORY.md` | global | what the agent has learned |
 | `USER.md` | **was** global | who the user is and how they want things done |
 
-Both are injected into every conversation's system prompt. The Mattermost adapter here
-runs with `MATTERMOST_ALLOW_ALL_USERS=true`, so every person in the team shares one
-`USER.md` — one person's stated preferences end up in everyone else's prompt. That is
-preference contamination and a mild privacy leak.
+Both are injected into every conversation's system prompt. Without the patch every
+person on a platform shares one `USER.md` — one person's stated preferences end up in
+everyone else's prompt. That is preference contamination and a mild privacy leak.
+
+It was written when the Mattermost adapter ran with `MATTERMOST_ALLOW_ALL_USERS=true`
+and anyone in the team could reach the bot. Mattermost is decommissioned and Matrix
+access is allowlisted to one user, so the patch currently guards nothing in practice —
+it is what makes widening `MATRIX_ALLOWED_USERS` safe, and stays for that reason.
 
 The patch partitions `USER.md` per platform identity:
 
@@ -30,8 +34,8 @@ The patch partitions `USER.md` per platform identity:
 - no identity (TUI, cron, one-shot) → the original global `memories/USER.md`
 - `MEMORY.md` stays global — shared agent knowledge is intentional
 
-`<safe_key>` is `<platform>-<id>` for filesystem-safe identifiers (Mattermost/Slack ids,
-numeric Telegram ids). Anything else — emails, unicode handles, hostile values like
+`<safe_key>` is `<platform>-<id>` for filesystem-safe identifiers (Slack ids, numeric
+Telegram ids). Anything else — emails, unicode handles, hostile values like
 `../../etc` — collapses to a stable `h-<sha256[:20]>` digest, so a platform-supplied
 identifier can never contribute a raw path component.
 

--- a/docs/postgres-consolidation.md
+++ b/docs/postgres-consolidation.md
@@ -1,7 +1,10 @@
 # Postgres Consolidation onto CloudNativePG
 
-Runbook for migrating the cluster's ten standalone `postgres:18-alpine` sidecar
+Runbook for migrating the cluster's nine standalone `postgres:18-alpine` sidecar
 containers onto the shared CloudNativePG cluster in the `database` namespace.
+
+Mattermost was a tenth. It was decommissioned in favour of the Matrix stack
+rather than migrated, so its sidecar is gone without ever moving.
 
 This **supersedes** the "Database Strategy: Individual DBs Per App" decision in
 `deployment-plan.md`.
@@ -9,10 +12,11 @@ This **supersedes** the "Database Strategy: Individual DBs Per App" decision in
 ## Why
 
 The per-app sidecar pattern gave isolation, but at a cost that grew with app
-count: ten single-instance databases with no HA, ten `pg_dump` CronJobs, ten
-manual major-version upgrades (see `.taskfiles/db-migrations/`), and no metrics
-or alerting on any of them. A single CNPG cluster gives declarative roles and
-databases, automatic failover, PodMonitor metrics, and one backup job.
+count: one single-instance database with no HA per app, one `pg_dump` CronJob
+per app, one manual major-version upgrade per app (see
+`.taskfiles/db-migrations/`), and no metrics or alerting on any of them. A
+single CNPG cluster gives declarative roles and databases, automatic failover,
+PodMonitor metrics, and one backup job.
 
 The trade is real and worth stating plainly: **this creates a single failure
 domain.** CNPG down means Forgejo, Authentik (and therefore SSO), Synapse and
@@ -28,7 +32,6 @@ failover and alerting, not eliminated.
 | atuin | tools | `atuin` | `atuin` |
 | zipline | tools | `zipline` | `zipline` |
 | mas | tools | `mas` | `mas` |
-| mattermost | tools | `mattermost` | `mattermost` |
 | nextcloud | tools | `nextcloud` | `nextcloud` |
 | synapse | tools | `synapse` | `synapse` (C collation) |
 | n8n | ai | `n8n` | `n8n` |
@@ -92,11 +95,10 @@ Manifests: `kubernetes/apps/database/postgres/app/`.
 | 3 | **zipline** | Small | Already uses a `postgres-init` init container — remove it. File uploads are a separate PVC; don't touch. |
 | 4 | **mas** | Small, but **Synapse depends on it for auth** — migrate well before Synapse | DSN lives inside `config.yaml` in `mas-secret`. MAS runs its own schema migrations at boot. |
 | 5 | **n8n** | Medium | `N8N_ENCRYPTION_KEY` must be unchanged or **every stored credential becomes unreadable**. Confirm it comes from the ExternalSecret, not a file generated on the PVC. |
-| 6 | **mattermost** | Medium | Validates the DSN strictly: `postgres://user:pass@host:5432/db?sslmode=disable&connect_timeout=10` |
-| 7 | **teslamate** | Large time-series; longest dump/restore | Check for `cube`/`earthdistance` extensions (add to `Database.spec.extensions`). The teslamate-grafana datasource secret needs updating too. |
-| 8 | **nextcloud** | Big and chatty; ~30 connections — this is the app that will make you care about `max_connections` | `occ maintenance:mode --on` first. After cutover: `occ maintenance:repair` and `occ db:add-missing-indices`. |
-| 9 | **synapse** | Schema-sensitive | **Hard requirement: `LC_COLLATE=C`, `LC_CTYPE=C`.** Use the `Database` CR with `localeCollate: C`, `localeCType: C` and **`template: template0`** (locale cannot be overridden from `template1`). Synapse refuses to start otherwise. Verify before restoring: `SELECT datcollate, datctype FROM pg_database WHERE datname='synapse'` |
-| 10 | **authentik** | **PG 17 → 18** and it is the IdP: breaking it costs SSO to Forgejo, Headlamp and Grafana | Dump using the **PG 18** `pg_dump` client against the 17 server (forward, never backward). Set `postgresql.enabled: false` on the bitnami subchart and drop the two `valuesFrom` targetPaths. Keep the PG17 PVC. **Verify the static kubeconfig works before starting** — apiserver OIDC goes with it. Do this last, on a day you can afford downtime. |
+| 6 | **teslamate** | Large time-series; longest dump/restore | Check for `cube`/`earthdistance` extensions (add to `Database.spec.extensions`). The teslamate-grafana datasource secret needs updating too. |
+| 7 | **nextcloud** | Big and chatty; ~30 connections — this is the app that will make you care about `max_connections` | `occ maintenance:mode --on` first. After cutover: `occ maintenance:repair` and `occ db:add-missing-indices`. |
+| 8 | **synapse** | Schema-sensitive | **Hard requirement: `LC_COLLATE=C`, `LC_CTYPE=C`.** Use the `Database` CR with `localeCollate: C`, `localeCType: C` and **`template: template0`** (locale cannot be overridden from `template1`). Synapse refuses to start otherwise. Verify before restoring: `SELECT datcollate, datctype FROM pg_database WHERE datname='synapse'` |
+| 9 | **authentik** | **PG 17 → 18** and it is the IdP: breaking it costs SSO to Forgejo, Headlamp and Grafana | Dump using the **PG 18** `pg_dump` client against the 17 server (forward, never backward). Set `postgresql.enabled: false` on the bitnami subchart and drop the two `valuesFrom` targetPaths. Keep the PG17 PVC. **Verify the static kubeconfig works before starting** — apiserver OIDC goes with it. Do this last, on a day you can afford downtime. |
 
 For Synapse:
 

--- a/kubernetes/apps/ai/hermes-agent/app/configmap-memory-patch.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/configmap-memory-patch.yaml
@@ -7,8 +7,8 @@ data:
   # Upstream PR NousResearch/hermes-agent#27183 ("Add per-user USER.md
   # isolation in MemoryStore"), which closes issue #27182. NOT merged
   # upstream as of 2026-09-02 — carried here as a runtime patch so the
-  # multi-user Mattermost adapter stops writing every person's preferences
-  # into one shared /opt/data/memories/USER.md.
+  # gateway stops writing every person's preferences into one shared
+  # /opt/data/memories/USER.md once more than one user is allowlisted.
   #
   # What it does: MemoryStore gains user_id/platform; when a platform
   # identity is present USER.md moves to memories/users/<safe_key>/USER.md

--- a/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-agent/app/helmrelease.yaml
@@ -16,9 +16,11 @@ spec:
         initContainers:
           # Carries upstream PR NousResearch/hermes-agent#27183 (per-user
           # USER.md isolation, issue #27182) into the stock image, which does
-          # not have it yet. Without it every Mattermost user in the mixos
-          # team shares one /opt/data/memories/USER.md, so one person's stated
-          # preferences are injected into everyone else's system prompt.
+          # not have it yet. Without it every platform user shares one
+          # /opt/data/memories/USER.md, so one person's stated preferences are
+          # injected into everyone else's system prompt. Matrix access is
+          # currently allowlisted to one user, so this guards the moment
+          # MATRIX_ALLOWED_USERS widens rather than a present-day leak.
           #
           # /opt/hermes is immutable in the published image, so the three
           # touched source files are copied to an emptyDir, patched there, and
@@ -99,10 +101,10 @@ spec:
               # value is deliberately treated as unset (falls through to
               # config.yaml) rather than as false.
               #
-              # Safe for the existing platform wiring: Mattermost (WebSocket)
-              # and Matrix (/sync long-poll) are outbound-connecting adapters,
-              # so the /p/<profile>/webhooks/<route> path change that
-              # multiplexing introduces applies to no registered webhook here.
+              # Safe for the existing platform wiring: Matrix (/sync
+              # long-poll) is an outbound-connecting adapter, so the
+              # /p/<profile>/webhooks/<route> path change that multiplexing
+              # introduces applies to no registered webhook here.
               # The default profile likewise keeps the unprefixed /v1/... API
               # listener on :8642 — only secondary profiles move to
               # /p/<profile>/v1/... — so open-webui's OPENAI_API_BASE_URL is


### PR DESCRIPTION
Phase 3 of the Mattermost decommission — cleanup. Follows #564 (cut the producers) and #565 (removed the app). Comment and prose only; no manifest behaviour changes.

## Verified live before writing this

- `kubectl -n tools get all,pvc,externalsecret,helmrelease,httproute | grep -i matter` → nothing left; the `mattermost` Kustomization is gone.
- The live `hermes-dotenv` secret has **0** `MATTERMOST_*` variables.
- hermes holds Synapse only — the `10.43.59.41:8065` connection from before #564 is gone, pod `2/2 Running`.

## Changes

- **hermes per-user `USER.md` patch** — its justification was Mattermost running with `MATTERMOST_ALLOW_ALL_USERS=true`. That is gone, but the patch is not: Matrix access is allowlisted to one user, so it now guards the moment `MATRIX_ALLOWED_USERS` widens rather than a present-day leak. Said plainly in both the HelmRelease comment and `docs/hermes-memory-patch.md`.
- **`docs/postgres-consolidation.md`** — Mattermost was counted among the ten sidecars awaiting migration. It was decommissioned instead of migrated, so it comes out of the target-state and order tables, the order renumbers to nine, and the intro records why it never moved.
- **`docs/architecture/authentication.md`** — drop the Mattermost auth-posture row.
- **`hermes helmrelease`** — the multiplexing note listed Mattermost (WebSocket) alongside Matrix as outbound-connecting adapters; only Matrix remains.

## Deliberately kept

Three Mattermost mentions are history, not staleness:

- `docs/matrix-webhooks.md:465` — why per-alert links must be built inside the transformation function (Slack's schema had a title link; hookshot's payload has no link field).
- `docs/hermes-memory-patch.md:26` — what the patch was originally written against.
- `externalsecret-dotenv.yaml:24` — why the `MATTERMOST_*` block is *absent* rather than never having existed, so nobody re-adds it.

`deployment-standards.md` already described the Discord → Mattermost → Matrix history correctly and needed no edit. `docs/matrix-webhooks.md`'s room→webhook map was already current.

## Validation

`validate:flux`, `validate:secret-keys`, `validate:substitutions`, `validate:routes` all exit 0.

https://claude.ai/code/session_01TguebKLBcer1vQEEP7ot61