### PR TITLE
feat(matrix): gate the Matrix app behind a group, allow the admin to publish rooms

### DIFF
--- a/kubernetes/apps/security/authentik/app/blueprints/00-foundation.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/00-foundation.yaml
@@ -5,8 +5,10 @@
 # this file, which guarantees these objects exist before they are referenced with !Find — blueprint
 # files are discovered with rglob() and have no inherent ordering.
 #
-# tier1/2/3 are access tiers. Membership is user data and is deliberately NOT declared here: listing
-# `users` would reconcile group membership away on every apply.
+# tier1/2/3 are access tiers. matrix-users gates the Matrix application specifically, because a
+# successful OIDC login there provisions a real Synapse account via MAS — an unbound application
+# would let any authentik user mint one. Membership is user data and is deliberately NOT declared
+# here: listing `users` would reconcile group membership away on every apply.
 #
 # headlamp-email-verified exists because kube-apiserver requires an `email_verified` claim when
 # oidc-username-claim=email, and authentik's built-in `email` scope hardcodes it to false. The
@@ -41,6 +43,14 @@ entries:
       attributes: {}
       is_superuser: false
       name: tier3
+      parents: []
+  - model: authentik_core.group
+    identifiers:
+      name: matrix-users
+    attrs:
+      attributes: {}
+      is_superuser: false
+      name: matrix-users
       parents: []
   - id: scope-headlamp-email
     model: authentik_providers_oauth2.scopemapping

--- a/kubernetes/apps/security/authentik/app/blueprints/20-oidc-integrations.yaml
+++ b/kubernetes/apps/security/authentik/app/blueprints/20-oidc-integrations.yaml
@@ -168,7 +168,8 @@ entries:
       refresh_token_validity: days=30
       signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
       sub_mode: user_username
-  - model: authentik_core.application
+  - id: app-matrix
+    model: authentik_core.application
     identifiers:
       slug: matrix
     attrs:
@@ -184,6 +185,22 @@ entries:
       policy_engine_mode: any
       provider: !KeyOf 'provider-matrix'
       slug: matrix
+  # An application with no bindings is open to every authenticated user, and a first login here
+  # provisions a Synapse account through MAS. Bind the matrix-users group so account creation is an
+  # explicit act: add the person to the group in authentik, then they can sign in. Membership is
+  # managed in the UI, not in a blueprint (see 00-foundation.yaml).
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf 'app-matrix'
+      group: !Find [authentik_core.group, [name, matrix-users]]
+      order: 0
+    attrs:
+      enabled: true
+      failure_result: false
+      negate: false
+      policy: null
+      timeout: 30
+      user: null
   - id: provider-grafana
     model: authentik_providers_oauth2.oauth2provider
     identifiers:


### PR DESCRIPTION
Two changes from the same thread of work: getting a second person onto the Matrix server safely, and making the mixOS space discoverable to them.

## 1. Gate the Matrix application behind `matrix-users`

The Matrix application in authentik had **no policy bindings**. In authentik that means every authenticated user can launch it — and a first login there provisions a real Synapse account through MAS (`registration_handler.register_user()` via `/_synapse/mas/...`). Anyone with an authentik account could mint themselves a Matrix identity.

- New `matrix-users` group in `00-foundation.yaml`, alongside tier1/2/3.
- Group-based `policybinding` on the Matrix application in `20-oidc-integrations.yaml` (the application entry gains an `id: app-matrix` anchor so the binding can target it).

Adding someone to Matrix is now an explicit act: add them to `matrix-users`, then they can sign in and get an account. Membership is user data managed in the UI, not declared in the blueprint — same reasoning as the existing tiers.

**After merge, add yourself to `matrix-users` first.** The binding applies to superusers too, so a new MAS login will be refused until you are in the group. Existing Element sessions are unaffected.

## 2. Allow the admin account to publish rooms to the directory

Publishing the mixOS space to the room directory returned `403 - Not allowed to publish room`, surfaced in Element only as "There was an error publishing this room".

Synapse denies publication by default: an unset `room_list_publication_rules` becomes an empty rule list, and `is_publishing_room_allowed()` falls through to deny. `alias_creation_rules` defaults the opposite way, to allow — which is why setting the local address `#mixos:matrix.thegeekybits.com` worked while publishing failed.

Adds a rule allowing only `@shawnmix` to publish. The directory is internal-only and publication is an admin act.

## Not included

No `auto_join_rooms`. Space and room access stays Matrix room state — published space, restricted child rooms — so users choose what to join.

https://claude.ai/code/session_016StbnvLqdr5iBzX6DQ1hAc