### PR TITLE
fix(synapse): allow the admin account to publish rooms to the directory

### DIFF
--- a/kubernetes/apps/tools/synapse/app/externalsecret.yaml
+++ b/kubernetes/apps/tools/synapse/app/externalsecret.yaml
@@ -32,6 +32,17 @@ spec:
           log_config: /data/log.config
           max_upload_size: 100M
           enable_registration: false
+          # Synapse denies room-directory publication by default (an unset
+          # room_list_publication_rules is an empty rule list, and the check
+          # falls through to deny) — publishing 403s in Element with no useful
+          # message. Alias *creation* defaults the other way, to allow, which is
+          # why setting a local address works but publishing does not. Allow
+          # only the admin account to publish; nobody else needs to.
+          room_list_publication_rules:
+            - user_id: "@shawnmix:matrix.${SECRET_DOMAIN}"
+              alias: "*"
+              room_id: "*"
+              action: allow
           federation_domain_whitelist: []
           trusted_key_servers: []
           suppress_key_server_warning: true


### PR DESCRIPTION
Follow-up to #568 — this commit was pushed to that branch after it had already merged, so it never landed.

## Problem

Publishing the mixOS space to the room directory failed. Element showed only "There was an error publishing this room"; the homeserver log had the real reason:

```
PUT /_matrix/client/v3/directory/list/room/!cqmnDYXKdfgqudpWri%3Amatrix.thegeekybits.com
SynapseError: 403 - Not allowed to publish room
```

## Cause

Synapse denies room-directory publication by default. An unset `room_list_publication_rules` becomes an empty rule list (`synapse/config/room_directory.py:57`) and `is_publishing_room_allowed()` falls through to `return False` (`:93`).

`alias_creation_rules` defaults the opposite way — to allow (`:44`) — which is why setting the local address `#mixos:matrix.thegeekybits.com` succeeded while the publish toggle 403'd. The asymmetry is what makes this confusing to hit.

## Fix

Allow only `@shawnmix` to publish. The directory is internal-only and publication is an admin act; no other account needs it.

## After merge

Reloader restarts Synapse on the secret change; then the publish toggle sticks. The space still needs its join rule set to Public for anyone to act on a directory listing.

https://claude.ai/code/session_016StbnvLqdr5iBzX6DQ1hAc