### PR TITLE
fix(talos,monitoring): give image GC runway ahead of eviction, and alert on it

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./externalsecret.yaml
   - ./httproute.yaml
   - ./configmap.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule.yaml
@@ -1,0 +1,59 @@
+---
+# Node disk-pressure coverage. The 2026-09-06 incident (43 Renovate PRs merged
+# in 90s -> cluster-wide rollout -> image-pull storm -> asgard-mpc-03 crossed
+# evictionHard imagefs.available<15% -> 46 CoreDNS pods evicted) produced ZERO
+# alerts. The stock kube-prometheus-stack rules all miss this shape:
+#   * NodeFilesystemAlmostOutOfSpace needs <5% free; the node bottomed at 15.6%.
+#   * NodeFilesystemSpaceFillingUp needs predict_linear() < 0 over 6h; the disk
+#     was dead flat at 81% full for days, so nothing was "filling up".
+#   * KubePodNotReady matches phase=~"Pending|Unknown" only — Failed/Evicted
+#     pods are invisible to it.
+#   * Nothing in the stack alerts on the node DiskPressure condition at all.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-disk-pressure
+spec:
+  groups:
+    - name: node-disk-pressure
+      rules:
+        - alert: KubeNodeDiskPressure
+          expr: kube_node_status_condition{condition="DiskPressure", status="true"} == 1
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: "{{ $labels.node }} is under DiskPressure"
+            description: >-
+              kubelet on {{ $labels.node }} has crossed an eviction threshold and
+              is shedding pods. Check /var usage and image GC on that node.
+
+        - alert: NodeEphemeralHeadroomLow
+          # The EPHEMERAL partition is capped at 95GB in talos/talconfig.yaml and
+          # holds containerd, etcd and pod logs. Warn while there is still room
+          # to act — evictionHard fires at 15%, image GC at 25% after the
+          # machine-kubelet.yaml patch.
+          expr: |
+            node_filesystem_avail_bytes{job="node-exporter", mountpoint="/var"}
+              / node_filesystem_size_bytes{job="node-exporter", mountpoint="/var"}
+              < 0.30
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "{{ $labels.instance }} /var only {{ $value | humanizePercentage }} free"
+            description: >-
+              Sustained low headroom on the EPHEMERAL partition. A rollout wave
+              that pulls a few GiB of images will trip DiskPressure from here.
+
+        - alert: KubePodEvicted
+          # KubePodNotReady never sees these — it filters to Pending|Unknown.
+          expr: kube_pod_status_reason{reason="Evicted"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Pod {{ $labels.namespace }}/{{ $labels.pod }} was evicted"
+            description: >-
+              Evicted pods persist as Failed objects until deleted. A burst of
+              these means a node crossed a resource eviction threshold.

--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -2,6 +2,18 @@ machine:
   kubelet:
     extraConfig:
       serializeImagePulls: false
+      # Image GC must fire well BEFORE the hard-eviction line, or it never runs
+      # in time. Kubernetes defaults put imageGCHighThresholdPercent (85% used)
+      # at exactly the same point as evictionHard imagefs.available<15%, so the
+      # first thing that ever reclaims image garbage is a mass pod eviction.
+      # 2026-09-06: asgard-mpc-03 sat at 81% full for days, a 43-PR Renovate
+      # merge triggered a cluster-wide rollout, and the resulting image pulls
+      # crossed 15% -> DiskPressure -> 46 CoreDNS pods evicted. GC then freed
+      # 34 GiB that had been reclaimable the whole time.
+      imageGCHighThresholdPercent: 75
+      imageGCLowThresholdPercent: 65
+      # Prune images unused for a week regardless of disk pressure.
+      imageMaximumGCAge: 168h
     nodeIP:
       validSubnets:
         - 10.0.3.0/24


### PR DESCRIPTION
## What happened

On **2026-09-06 11:13–11:15 EDT**, 43 Renovate PRs merged to `main` in a 90-second window. Flux applied them via the webhook, nearly every workload in the cluster rolled at once, and the resulting image pulls pushed `asgard-mpc-03` past kubelet's hard eviction threshold.

| Time (UTC) | `/var` free on `-03` | Event |
|---|---|---|
| steady | 16.64 GiB (18.8%) | flat for days — no headroom |
| 15:13:30 | | rollout wave starts landing on the node |
| 15:15:00 | 13.84 GiB (15.6%) | crosses `evictionHard imagefs.available<15%` |
| 15:14:51–57 | | DiskPressure; **46 CoreDNS pods rejected in 6 seconds** |
| 15:16:30 | 50.6 GiB | image GC reclaims ~34 GiB |
| 15:19:53 | | DiskPressure clears |

CoreDNS absorbed all 46 rejections because it carries a `required` nodeAffinity on `node-role.kubernetes.io/control-plane` — only 3 candidate nodes, and the two healthy replicas already held `-01` and `-02`. Every ReplicaSet replacement was bound to `-03` during the ~6s before the `disk-pressure:NoSchedule` taint propagated. DNS itself stayed up throughout.

## Why the node could never save itself

Kubernetes defaults put `imageGCHighThresholdPercent` (85% used) at **exactly the same point** as `evictionHard imagefs.available<15%`, and Talos leaves `imageMaximumGCAge: 0s`. Image garbage is therefore only ever collected *by* a mass eviction. 34 GiB had been reclaimable for days.

`talos/patches/global/machine-kubelet.yaml`:
- `imageGCHighThresholdPercent: 75` / `imageGCLowThresholdPercent: 65` — ~9 GiB of runway ahead of the eviction line
- `imageMaximumGCAge: 168h` — prune week-old unused images regardless of pressure

## Why nothing alerted

The Alertmanager pipeline is healthy and routes to Matrix. **No rule matched.** Every stock kube-prometheus-stack rule misses this shape:

| Rule | Why it missed |
|---|---|
| `NodeFilesystemAlmostOutOfSpace` | needs <5% free; node bottomed at 15.6% |
| `NodeFilesystemSpaceFillingUp` | needs `predict_linear() < 0` over 6h; disk was dead flat at 81% full |
| `KubePodNotReady` | matches `phase=~"Pending\|Unknown"` — `Failed`/`Evicted` pods are invisible to it |
| *(none)* | nothing in the stack covers the node `DiskPressure` condition |

New `PrometheusRule` in `kube-prometheus-stack/app/` adds `KubeNodeDiskPressure` (critical, 2m), `NodeEphemeralHeadroomLow` (warning, `/var` <30% for 1h), and `KubePodEvicted` (warning, 15m).

## Deploy notes

- The **PrometheusRule ships via Flux** on merge.
- The **Talos patch does not.** Kubelet config lives in the Talos machine config and needs `task talos:apply-node IP=10.0.3.2x` per node. It restarts kubelet, no reboot.
- ⚠️ **Do not run `apply-node` yet.** `talos/talenv.yaml` in git says Talos `v1.13.10` / k8s `v1.37.0`; the cluster is actually running Talos `v1.11.3` / k8s `v1.34.1`. `talhelper genconfig` currently fails outright (`version of Kubernetes 1.37.0 is too new to be used with Talos 1.13.10`), and applying that config blind would jump kubelet three minors past the control plane. That drift predates this PR and needs resolving separately.

## Validation

- `task validate:flux` — 162 passed
- `kubectl apply --dry-run=server` on the PrometheusRule — accepted by the operator's promtool webhook
- `talhelper genconfig` against the running `v1.34.1` renders the kubelet block correctly

https://claude.ai/code/session_01CjqKEYW1XjBw88KFMp2ATg
